### PR TITLE
fix CapabilityProxy.Proxy.getAllPrivate + test coverage

### DIFF
--- a/contracts/CapabilityProxy.cdc
+++ b/contracts/CapabilityProxy.cdc
@@ -60,7 +60,7 @@ pub contract CapabilityProxy {
         }
 
         pub fun getAllPrivate(): [Capability] {
-            return self.publicCapabilities.values
+            return self.privateCapabilities.values
         }
 
         pub fun findFirstPublicType(_ type: Type): Type? {
@@ -85,6 +85,9 @@ pub contract CapabilityProxy {
         // ------- End Getter methods
 
         pub fun addCapability(cap: Capability, isPublic: Bool) {
+            pre {
+                cap.check<&AnyResource>(): "Invalid Capability provided"
+            }
             if isPublic {
                 self.publicCapabilities.insert(key: cap.getType(), cap)
             } else {

--- a/scripts/proxy/find_nft_provider_cap.cdc
+++ b/scripts/proxy/find_nft_provider_cap.cdc
@@ -1,0 +1,23 @@
+import "CapabilityProxy"
+
+import "NonFungibleToken"
+import "ExampleNFT"
+
+pub fun main(addr: Address): Bool {
+    let acct = getAuthAccount(addr)
+
+    let proxy = 
+        acct.getCapability<&CapabilityProxy.Proxy{CapabilityProxy.GetterPrivate}>(CapabilityProxy.PrivatePath).borrow()
+        ?? panic("could not borrow proxy")
+
+    let desiredType = Type<Capability<&ExampleNFT.Collection{NonFungibleToken.Provider}>>()
+    let foundType = proxy.findFirstPrivateType(desiredType) ?? panic("no type found")
+    
+    let nakedCap = proxy.getPrivateCapability(foundType) ?? panic("requested capability type was not found")
+
+    // we don't need to do anything with this cap, being able to cast here is enough to know
+    // that this works
+    let cap = nakedCap as! Capability<&{NonFungibleToken.Provider}>
+    
+    return true
+}

--- a/scripts/proxy/get_all_private_caps.cdc
+++ b/scripts/proxy/get_all_private_caps.cdc
@@ -1,0 +1,15 @@
+import "CapabilityProxy"
+
+import "NonFungibleToken"
+import "ExampleNFT"
+
+pub fun main(address: Address): Bool {
+    let privateCaps: [Capability] = getAuthAccount(addr).getCapability<&CapabilityProxy.Proxy>(CapabilityProxy.PrivatePath)
+        .borrow()
+        ?.getAllPrivate()
+        ?? panic("could not borrow proxy")
+
+    let desiredType: Type = Type<Capability<&ExampleNFT.Collection{NonFungibleToken.Provider}>>()
+
+    return privateCaps.length == 1 && privateCaps[0].getType() == desiredType
+}

--- a/scripts/proxy/get_all_public_caps.cdc
+++ b/scripts/proxy/get_all_public_caps.cdc
@@ -1,0 +1,15 @@
+import "CapabilityProxy"
+
+import "NonFungibleToken"
+import "ExampleNFT"
+
+pub fun main(address: Address): Bool {
+    let publicCaps: [Capability] = getAccount(address).getCapability<&{CapabilityProxy.GetterPublic}>(CapabilityProxy.PublicPath)
+        .borrow()
+        ?.getAllPublic()
+        ?? panic("could not borrow proxy")
+    
+    let desiredType: Type = Type<Capability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic}>>()
+    
+    return publicCaps.length == 0 && publicCaps[0].getType() == desiredType
+}

--- a/scripts/proxy/get_nft_provider.cdc
+++ b/scripts/proxy/get_nft_provider.cdc
@@ -1,0 +1,21 @@
+import "CapabilityProxy"
+
+import "NonFungibleToken"
+import "ExampleNFT"
+
+pub fun main(addr: Address): Bool {
+    let acct = getAuthAccount(addr)
+
+    let proxy = 
+        acct.getCapability<&CapabilityProxy.Proxy{CapabilityProxy.GetterPrivate}>(CapabilityProxy.PrivatePath).borrow()
+        ?? panic("could not borrow proxy")
+
+    let capType = Type<Capability<&ExampleNFT.Collection{NonFungibleToken.Provider}>>()
+    let nakedCap = proxy.getPrivateCapability(capType) ?? panic("requested capability type was not found")
+
+    // we don't need to do anything with this cap, being able to cast here is enough to know
+    // that this works
+    let cap = nakedCap as! Capability<&ExampleNFT.Collection{NonFungibleToken.Provider}>
+    
+    return true
+}

--- a/test/CapabilityProxy_tests.cdc
+++ b/test/CapabilityProxy_tests.cdc
@@ -28,6 +28,19 @@ pub fun testShareExampleNFTCollectionPublic() {
     sharePublicExampleNFT(signer)
     getExampleNFTCollectionFromProxy(signer)
     findExampleNFTCollectionType(signer)
+    getAllPublicContainsCollection(signer)
+}
+
+pub fun testShareExampleNFTCollectionPrivate() {
+    let signer = accounts["creator"]!
+    setupProxy(signer)
+
+    setupNFTCollection(signer)
+
+    sharePrivateExampleNFT(signer)
+    getExampleNFTProviderFromProxy(signer)
+    findExampleNFTProviderType(signer)
+    getAllPrivateContainsProvider(signer)
 }
 
 // END SECTION - Test Cases
@@ -192,6 +205,11 @@ pub fun sharePublicExampleNFT(_ acct: Test.Account) {
     txExecutor(txCode, [acct], [], nil, nil)
 }
 
+pub fun sharePrivateExampleNFT(_ acct: Test.Account) {
+    let txCode = loadCode("proxy/add_private_nft_collection.cdc", "transactions")
+    txExecutor(txCode, [acct], [], nil, nil)
+}
+
 pub fun setupNFTCollection(_ acct: Test.Account) {
     let txCode = loadCode("example-nft/setup_full.cdc", "transactions")
     txExecutor(txCode, [acct], [], nil, nil)
@@ -216,8 +234,28 @@ pub fun getExampleNFTCollectionFromProxy(_ owner: Test.Account) {
     assert(borrowed, message: "failed to borrow proxy")
 }
 
+pub fun getExampleNFTProviderFromProxy(_ owner: Test.Account) {
+    let borrowed = scriptExecutor("proxy/get_nft_provider.cdc", [owner.address])! as! Bool
+    assert(borrowed, message: "failed to borrow proxy")
+}
+
+pub fun getAllPublicContainsCollection(_ owner: Test.Account) {
+    let success = scriptExecutor("proxy/get_all_public_caps.cdc", [owner.address])! as! Bool
+    assert(success, message: "failed to borrow proxy")
+}
+
+pub fun getAllPrivateContainsProvider(_ owner: Test.Account) {
+    let success = scriptExecutor("proxy/get_all_private_capts.cdc", [owner.address])! as! Bool
+    assert(success, message: "failed to borrow proxy")
+}
+
 pub fun findExampleNFTCollectionType(_ owner: Test.Account) {
     let borrowed = scriptExecutor("proxy/find_nft_collection_cap.cdc", [owner.address])! as! Bool
+    assert(borrowed, message: "failed to borrow proxy")
+}
+
+pub fun findExampleNFTProviderType(_ owner: Test.Account) {
+    let borrowed = scriptExecutor("proxy/find_nft_provider_cap.cdc", [owner.address])! as! Bool
     assert(borrowed, message: "failed to borrow proxy")
 }
 

--- a/transactions/proxy/add_private_nft_collection.cdc
+++ b/transactions/proxy/add_private_nft_collection.cdc
@@ -1,0 +1,18 @@
+import "CapabilityProxy"
+
+import "NonFungibleToken"
+import "MetadataViews"
+import "ExampleNFT"
+
+transaction {
+    prepare(acct: AuthAccount) {
+        let proxy = acct.borrow<&CapabilityProxy.Proxy>(from: CapabilityProxy.StoragePath)
+            ?? panic("proxy not found")
+        
+        let d = ExampleNFT.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
+        
+        let sharedCap = acct.getCapability<&ExampleNFT.Collection{NonFungibleToken.Provider}>(d.providerPath)
+        
+        proxy.addCapability(cap: sharedCap, isPublic: false)
+    }
+}


### PR DESCRIPTION
Closes: #60

Fixing return value for `CapabilityProxy.Proxy.getAllPrivate()` to return privateCapabilities and add test case coverage for both public and private return values.