### PR TITLE
Fix denylist filter

### DIFF
--- a/contracts/CapabilityFilter.cdc
+++ b/contracts/CapabilityFilter.cdc
@@ -41,7 +41,7 @@ pub contract CapabilityFilter {
                 return !self.deniedTypes.containsKey(item.getType())
             }
 
-            return true
+            return false
         }
 
         pub fun getDetails(): AnyStruct {

--- a/scripts/proxy/get_all_private_caps.cdc
+++ b/scripts/proxy/get_all_private_caps.cdc
@@ -4,7 +4,7 @@ import "NonFungibleToken"
 import "ExampleNFT"
 
 pub fun main(address: Address): Bool {
-    let privateCaps: [Capability] = getAuthAccount(addr).getCapability<&CapabilityProxy.Proxy>(CapabilityProxy.PrivatePath)
+    let privateCaps: [Capability] = getAuthAccount(address).getCapability<&CapabilityProxy.Proxy{CapabilityProxy.GetterPrivate}>(CapabilityProxy.PrivatePath)
         .borrow()
         ?.getAllPrivate()
         ?? panic("could not borrow proxy")

--- a/scripts/proxy/get_all_public_caps.cdc
+++ b/scripts/proxy/get_all_public_caps.cdc
@@ -4,12 +4,12 @@ import "NonFungibleToken"
 import "ExampleNFT"
 
 pub fun main(address: Address): Bool {
-    let publicCaps: [Capability] = getAccount(address).getCapability<&{CapabilityProxy.GetterPublic}>(CapabilityProxy.PublicPath)
+    let publicCaps: [Capability] = getAccount(address).getCapability<&CapabilityProxy.Proxy{CapabilityProxy.GetterPublic}>(CapabilityProxy.PublicPath)
         .borrow()
         ?.getAllPublic()
         ?? panic("could not borrow proxy")
     
-    let desiredType: Type = Type<Capability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic}>>()
+    let desiredType: Type = Type<Capability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>>()
     
-    return publicCaps.length == 0 && publicCaps[0].getType() == desiredType
+    return publicCaps.length == 1 && publicCaps[0].getType() == desiredType
 }

--- a/test/CapabilityProxy_tests.cdc
+++ b/test/CapabilityProxy_tests.cdc
@@ -245,7 +245,7 @@ pub fun getAllPublicContainsCollection(_ owner: Test.Account) {
 }
 
 pub fun getAllPrivateContainsProvider(_ owner: Test.Account) {
-    let success = scriptExecutor("proxy/get_all_private_capts.cdc", [owner.address])! as! Bool
+    let success = scriptExecutor("proxy/get_all_private_caps.cdc", [owner.address])! as! Bool
     assert(success, message: "failed to borrow proxy")
 }
 


### PR DESCRIPTION
Related: #61

Updating `DenylistFilter.allowed()` to return false on invalid Capabilities. Also fixing failing `CapabilityProxy` test cases & supporting scripts.