### PR TITLE
add capability checks & test coverage in HybridCustody

### DIFF
--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -140,13 +140,9 @@ pub contract HybridCustody {
         // addCapabilityToProxy
         // Adds a capability to a parent's managed @ProxyAccount resource. The Capability can be made public,
         // permitting anyone to borrow it.
-        pub fun addCapabilityToProxy(parent: Address, _ cap: Capability, isPublic: Bool) {
-            pre {
-                cap.check<&AnyResource>(): "Invalid Capability provided"
-            }
-        }
+        pub fun addCapabilityToProxy(parent: Address, cap: Capability, isPublic: Bool)
 
-        pub fun removeCapabilityFromProxy(parent: Address, _ cap: Capability)
+        pub fun removeCapabilityFromProxy(parent: Address, cap: Capability)
     }
 
     // Public methods exposed on a proxy account resource. ChildAccountPublic will share
@@ -234,7 +230,7 @@ pub contract HybridCustody {
         // For example, Dapper Wallet parent account's should not be able to retrieve any FungibleToken Provider capabilities.
         pub let filter: Capability<&{CapabilityFilter.Filter}>?
 
-        pub fun addAccount(_ cap: Capability<&{AccountPrivate, AccountPublic, MetadataViews.Resolver}>) {
+        pub fun addAccount(cap: Capability<&{AccountPrivate, AccountPublic, MetadataViews.Resolver}>) {
             pre {
                 self.accounts[cap.address] == nil: "There is already a child account with this address"
             }
@@ -276,7 +272,7 @@ pub contract HybridCustody {
             emit AccountUpdated(id: id, child: cap.address, parent: self.owner!.address, proxy: true, active: false)
         }
 
-        pub fun addOwnedAccount(_ cap: Capability<&{OwnedAccount, ChildAccountPublic, ChildAccountPrivate, MetadataViews.Resolver}>) {
+        pub fun addOwnedAccount(cap: Capability<&{OwnedAccount, ChildAccountPublic, ChildAccountPrivate, MetadataViews.Resolver}>) {
             pre {
                 self.ownedAccounts[cap.address] == nil: "There is already a child account with this address"
             }
@@ -433,11 +429,11 @@ pub contract HybridCustody {
             self.managerCapabilityFilter = managerCapabilityFilter
         }
 
-        pub fun setCapabilityFactory(_ cap: Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>) {
+        pub fun setCapabilityFactory(cap: Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>) {
             self.factory = cap
         }
 
-        pub fun setCapabilityFilter(_ cap: Capability<&{CapabilityFilter.Filter}>) {
+        pub fun setCapabilityFilter(cap: Capability<&{CapabilityFilter.Filter}>) {
             self.filter = cap
         }
 
@@ -788,12 +784,12 @@ pub contract HybridCustody {
 
         pub fun setCapabilityFactoryForParent(parent: Address, cap: Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>) {
             let p = self.borrowProxyAccount(parent: parent) ?? panic("could not find parent address")
-            p.setCapabilityFactory(cap)
+            p.setCapabilityFactory(cap: cap)
         }
 
         pub fun setCapabilityFilterForParent(parent: Address, cap: Capability<&{CapabilityFilter.Filter}>) {
             let p = self.borrowProxyAccount(parent: parent) ?? panic("could not find parent address")
-            p.setCapabilityFilter(cap)
+            p.setCapabilityFilter(cap: cap)
         }
 
         pub fun borrowCapabilityProxyForParent(parent: Address): &CapabilityProxy.Proxy? {
@@ -801,13 +797,13 @@ pub contract HybridCustody {
             return self.borrowAccount().borrow<&CapabilityProxy.Proxy>(from: StoragePath(identifier: identifier)!)
         }
 
-        pub fun addCapabilityToProxy(parent: Address, _ cap: Capability, isPublic: Bool) {
+        pub fun addCapabilityToProxy(parent: Address, cap: Capability, isPublic: Bool) {
             let p = self.borrowProxyAccount(parent: parent) ?? panic("could not find parent address")
             let proxy = self.borrowCapabilityProxyForParent(parent: parent) ?? panic("could not borrow capability proxy resource for parent address")
             proxy.addCapability(cap: cap, isPublic: isPublic)
         }
 
-        pub fun removeCapabilityFromProxy(parent: Address, _ cap: Capability) {
+        pub fun removeCapabilityFromProxy(parent: Address, cap: Capability) {
             let p = self.borrowProxyAccount(parent: parent) ?? panic("could not find parent address")
             let proxy = self.borrowCapabilityProxyForParent(parent: parent) ?? panic("could not borrow capability proxy resource for parent address")
             proxy.removeCapability(cap: cap)

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -140,7 +140,11 @@ pub contract HybridCustody {
         // addCapabilityToProxy
         // Adds a capability to a parent's managed @ProxyAccount resource. The Capability can be made public,
         // permitting anyone to borrow it.
-        pub fun addCapabilityToProxy(parent: Address, _ cap: Capability, isPublic: Bool)
+        pub fun addCapabilityToProxy(parent: Address, _ cap: Capability, isPublic: Bool) {
+            pre {
+                cap.check<&AnyResource>(): "Invalid Capability provided"
+            }
+        }
 
         pub fun removeCapabilityFromProxy(parent: Address, _ cap: Capability)
     }
@@ -172,7 +176,11 @@ pub contract HybridCustody {
         pub fun getPublicCapFromProxy(type: Type): Capability?
 
         access(contract) fun redeemedCallback(_ addr: Address)
-        access(contract) fun setManagerCapabilityFilter(_ managerCapabilityFilter: Capability<&{CapabilityFilter.Filter}>?)
+        access(contract) fun setManagerCapabilityFilter(_ managerCapabilityFilter: Capability<&{CapabilityFilter.Filter}>?) {
+            pre {
+                managerCapabilityFilter == nil || managerCapabilityFilter!.check(): "Invalid Manager Capability Filter"
+            }
+        }
         access(contract) fun setDisplay(_ d: MetadataViews.Display)
         access(contract) fun parentRemoveChildCallback(parent: Address)
     }
@@ -186,7 +194,11 @@ pub contract HybridCustody {
 
         // TODO: Owned account methods
         pub fun borrowOwnedAccount(addr: Address): &{OwnedAccount, ChildAccountPublic, ChildAccountPrivate}?
-        pub fun setManagerCapabilityFilter(cap: Capability<&{CapabilityFilter.Filter}>?, childAddress: Address)
+        pub fun setManagerCapabilityFilter(cap: Capability<&{CapabilityFilter.Filter}>?, childAddress: Address) {
+            pre {
+                cap == nil || cap!.check(): "Invalid Manager Capability Filter"
+            }
+        }
     }
 
     // Functions anyone can call on a manager to get information about an account such as
@@ -349,6 +361,9 @@ pub contract HybridCustody {
         }
 
         init(filter: Capability<&{CapabilityFilter.Filter}>?) {
+            pre {
+                filter == nil || filter!.check(): "Invalid CapabilityFilter Filter capability provided"
+            }
             self.accounts = {}
             self.ownedAccounts = {}
             self.filter = filter
@@ -524,6 +539,12 @@ pub contract HybridCustody {
             _ proxy: Capability<&CapabilityProxy.Proxy{CapabilityProxy.GetterPublic, CapabilityProxy.GetterPrivate}>,
             _ parent: Address
         ) {
+            pre {
+                childCap.check(): "Provided childCap Capability is invalid"
+                factory.check(): "Provided factory Capability is invalid"
+                filter.check(): "Provided filter Capability is invalid"
+                proxy.check(): "Provided proxy Capability is invalid"
+            }
             self.childCap = childCap
             self.factory = factory
             self.filter = filter
@@ -858,6 +879,9 @@ pub contract HybridCustody {
     }
 
     pub fun createManager(filter: Capability<&{CapabilityFilter.Filter}>?): @Manager {
+        pre {
+            filter == nil || filter!.check(): "Invalid CapabilityFilter Filter capability provided"
+        }
         let manager <- create Manager(filter: filter)
         emit CreatedManager(id: manager.uuid)
         return <- manager

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -140,7 +140,11 @@ pub contract HybridCustody {
         // addCapabilityToProxy
         // Adds a capability to a parent's managed @ProxyAccount resource. The Capability can be made public,
         // permitting anyone to borrow it.
-        pub fun addCapabilityToProxy(parent: Address, cap: Capability, isPublic: Bool)
+        pub fun addCapabilityToProxy(parent: Address, cap: Capability, isPublic: Bool) {
+            pre {
+                cap.check<&AnyResource>(): "Invalid Capability provided"
+            }
+        }
 
         pub fun removeCapabilityFromProxy(parent: Address, cap: Capability)
     }

--- a/scripts/test/create_manager_with_invalid_filter.cdc
+++ b/scripts/test/create_manager_with_invalid_filter.cdc
@@ -1,0 +1,12 @@
+import "CapabilityFilter"
+import "HybridCustody"
+
+pub fun main(address: Address): Bool {
+    // Retrieving invalid Filter capability
+    let invalidFilterCap = getAuthAccount(address).getCapability<&{CapabilityFilter.Filter}>(CapabilityFilter.PrivatePath)
+    // This step should fail due to CapabilityFilter.Filter Capability check on Manager init
+    let manager <- HybridCustody.createManager(filter: invalidFilterCap)
+    // Destroy and return
+    destroy manager
+    return false
+}

--- a/test/HybridCustody_tests.cdc
+++ b/test/HybridCustody_tests.cdc
@@ -139,6 +139,16 @@ pub fun testProxyAccount_getPublicCapability() {
     scriptExecutor("hybrid-custody/get_nft_collection_public_capability.cdc", [parent.address, child.address])
 }
 
+pub fun testCreateManagerWithInvalidFilterFails() {
+    let parent = blockchain.createAccount()
+
+    let error = expectScriptFailure("test/create_manager_with_invalid_filter.cdc", [parent.address])
+    assert(
+        contains(error, "Invalid CapabilityFilter Filter capability provided"),
+        message: "Manager init did not fail as expected on invalid Filter Capability"
+    )
+}
+
 pub fun testCheckParentRedeemedStatus() {
     let child = blockchain.createAccount()
     let parent = blockchain.createAccount()

--- a/transactions/hybrid-custody/accept_ownership.cdc
+++ b/transactions/hybrid-custody/accept_ownership.cdc
@@ -27,6 +27,6 @@ transaction(childAddress: Address, filterAddress: Address?, filterPath: PublicPa
         let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager no found")
 
-        manager.addOwnedAccount(cap)
+        manager.addOwnedAccount(cap: cap)
     }
 }

--- a/transactions/hybrid-custody/add_example_nft2_collection_to_proxy.cdc
+++ b/transactions/hybrid-custody/add_example_nft2_collection_to_proxy.cdc
@@ -15,6 +15,6 @@ transaction(parent: Address, isPublic: Bool) {
         acct.link<&ExampleNFT2.Collection>(path, target: ExampleNFT2.CollectionStoragePath)
         let cap = acct.getCapability<&ExampleNFT2.Collection>(path)
 
-        c.addCapabilityToProxy(parent: parent, cap, isPublic: isPublic)
+        c.addCapabilityToProxy(parent: parent, cap: cap, isPublic: isPublic)
     }
 }

--- a/transactions/hybrid-custody/add_example_nft_collection_to_proxy.cdc
+++ b/transactions/hybrid-custody/add_example_nft_collection_to_proxy.cdc
@@ -15,6 +15,6 @@ transaction(parent: Address, isPublic: Bool) {
         acct.link<&ExampleNFT.Collection>(path, target: ExampleNFT.CollectionStoragePath)
         let cap = acct.getCapability<&ExampleNFT.Collection>(path)
 
-        c.addCapabilityToProxy(parent: parent, cap, isPublic: isPublic)
+        c.addCapabilityToProxy(parent: parent, cap: cap, isPublic: isPublic)
     }
 }

--- a/transactions/hybrid-custody/onboarding/blockchain_native.cdc
+++ b/transactions/hybrid-custody/onboarding/blockchain_native.cdc
@@ -127,7 +127,7 @@ transaction(
         // Get a reference to the Manager and add the account
         let managerRef = parent.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager no found")
-        managerRef.addAccount(cap)
+        managerRef.addAccount(cap: cap)
     }
 }
  

--- a/transactions/hybrid-custody/redeem_account.cdc
+++ b/transactions/hybrid-custody/redeem_account.cdc
@@ -28,6 +28,6 @@ transaction(childAddress: Address, filterAddress: Address?, filterPath: PublicPa
         let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager no found")
 
-        manager.addAccount(cap)
+        manager.addAccount(cap: cap)
     }
 }

--- a/transactions/hybrid-custody/setup_multi_sig.cdc
+++ b/transactions/hybrid-custody/setup_multi_sig.cdc
@@ -68,6 +68,6 @@ transaction(parentFilterAddress: Address?, childAccountFactoryAddress: Address, 
         let manager = parentAcct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager no found")
 
-        manager.addAccount(cap)
+        manager.addAccount(cap: cap)
     }
 }


### PR DESCRIPTION
Closes: #63

Added checks on Capability parameters throughout the HybridCustody contract, along with test coverage for Manager init values. I realize some of these checks are redundant (e.g. `HybridCustody.createManager()` flowing through to `Manager.init()`), but helpful for readability.