### PR TITLE
Update CapabilityFactory Manager

### DIFF
--- a/contracts/CapabilityFactory.cdc
+++ b/contracts/CapabilityFactory.cdc
@@ -1,23 +1,68 @@
+/// # Capability Factory
+///
+/// This contract defines a Factory interface and a Manager resource to contain Factory implementations, as well as a
+/// Getter interface for retrieval of contained Factories.
+/// 
+/// A Factory is defines a method getCapability() which defines the retrieval pattern of a Capability from a given
+/// account at the specified path. This pattern arose out of a need to retrieve arbitrary & castable Capabilities from
+/// an account under the static typing constraints inherent to Cadence.
+///
+/// The Manager resource is a container for Factories, and implements the Getter interface.
+///
+/// **Note:** It's generally an anti-pattern to pass around AuthAccount references; however, the need for castable
+/// Capabilities is critical to the use case of Hybrid Custody. It's advised to use Factories sparingly and only for
+/// cases where Capabilities must be castable by the caller.
+///
 pub contract CapabilityFactory {
+    
     pub let StoragePath: StoragePath
     pub let PrivatePath: PrivatePath
     pub let PublicPath: PublicPath
     
+    /// Factory structures a common interface for Capability retrieval from a given account at a specified path
+    ///
     pub struct interface Factory {
         pub fun getCapability(acct: &AuthAccount, path: CapabilityPath): Capability
     }
 
+    /// Getter defines an interface for retrieval of a Factory if contained within the implementing resource
+    ///
     pub resource interface Getter {
         pub fun getFactory(_ t: Type): {CapabilityFactory.Factory}?
     }
 
+    /// Manager is a resource that contains Factories and implements the Getter interface for retrieval of contained
+    /// Factories
+    ///
     pub resource Manager: Getter {
+        /// Mapping of Factories indexed on Type of Capability they retrieve
         pub let factories: {Type: {CapabilityFactory.Factory}}
 
+        /// Adds a Factory to the Manager, conditioned on the Factory not already existing
+        ///
+        /// @param t: Type of Capability the Factory retrieves
+        /// @param f: Factory to add
+        ///
         pub fun addFactory(_ t: Type, _ f: {CapabilityFactory.Factory}) {
+            pre {
+                !self.factories.containsKey(t): "Factory of given type already exists"
+            }
             self.factories[t] = f
         }
 
+        /// Updates a Factory in the Manager, adding if it didn't already exist
+        ///
+        /// @param t: Type of Capability the Factory retrieves
+        /// @param f: Factory to replace existing Factory
+        ///
+        pub fun updateFactory(_ t: Type, _ f: {CapabilityFactory.Factory}) {
+            self.factories[t] = f
+        }
+
+        /// Removes a Factory from the Manager, returning it or nil if it doesn't exist
+        ///
+        /// @param t: Type the Factory is indexed on
+        ///
         pub fun getFactory(_ t: Type): {CapabilityFactory.Factory}? {
             return self.factories[t]
         }
@@ -27,12 +72,15 @@ pub contract CapabilityFactory {
         }
     }
 
+    /// Creates a Manager resource
+    ///
+    /// @return Manager resource
     pub fun createFactoryManager(): @Manager {
         return <- create Manager()
     }
 
     init() {
-        let identifier = "CapabilityFactory".concat(self.account.address.toString())
+        let identifier = "CapabilityFactory_".concat(self.account.address.toString())
         self.StoragePath = StoragePath(identifier: identifier)!
         self.PrivatePath = PrivatePath(identifier: identifier)!
         self.PublicPath = PublicPath(identifier: identifier)!

--- a/contracts/CapabilityFactory.cdc
+++ b/contracts/CapabilityFactory.cdc
@@ -28,6 +28,7 @@ pub contract CapabilityFactory {
     /// Getter defines an interface for retrieval of a Factory if contained within the implementing resource
     ///
     pub resource interface Getter {
+        pub fun getSupportedTypes(): [Type]
         pub fun getFactory(_ t: Type): {CapabilityFactory.Factory}?
     }
 
@@ -37,6 +38,22 @@ pub contract CapabilityFactory {
     pub resource Manager: Getter {
         /// Mapping of Factories indexed on Type of Capability they retrieve
         pub let factories: {Type: {CapabilityFactory.Factory}}
+
+        /// Retrieves a list of Types supported by contained Factories
+        ///
+        /// @return List of Types supported by the Manager
+        ///
+        pub fun getSupportedTypes(): [Type] {
+            return self.factories.keys
+        }
+
+        /// Retrieves a Factory from the Manager, returning it or nil if it doesn't exist
+        ///
+        /// @param t: Type the Factory is indexed on
+        ///
+        pub fun getFactory(_ t: Type): {CapabilityFactory.Factory}? {
+            return self.factories[t]
+        }
 
         /// Adds a Factory to the Manager, conditioned on the Factory not already existing
         ///
@@ -59,12 +76,12 @@ pub contract CapabilityFactory {
             self.factories[t] = f
         }
 
-        /// Removes a Factory from the Manager, returning it or nil if it doesn't exist
+        /// Removes a Factory from the Manager, returning it or nil if it didn't exist
         ///
         /// @param t: Type the Factory is indexed on
         ///
-        pub fun getFactory(_ t: Type): {CapabilityFactory.Factory}? {
-            return self.factories[t]
+        pub fun removeFactory(_ t: Type): {CapabilityFactory.Factory}? {
+            return self.factories.remove(key: t)
         }
 
         init () {

--- a/contracts/CapabilityFilter.cdc
+++ b/contracts/CapabilityFilter.cdc
@@ -127,7 +127,7 @@ pub contract CapabilityFilter {
     }
 
     init() {
-        let identifier = "CapabilityFilter".concat(self.account.address.toString())
+        let identifier = "CapabilityFilter_".concat(self.account.address.toString())
         
         self.StoragePath = StoragePath(identifier: identifier)!
         self.PublicPath = PublicPath(identifier: identifier)!

--- a/contracts/CapabilityProxy.cdc
+++ b/contracts/CapabilityProxy.cdc
@@ -119,7 +119,7 @@ pub contract CapabilityProxy {
     }
     
     init() {
-        let identifier = "CapabilityProxy".concat(self.account.address.toString())
+        let identifier = "CapabilityProxy_".concat(self.account.address.toString())
         self.StoragePath = StoragePath(identifier: identifier)!
         self.PrivatePath = PrivatePath(identifier: identifier)!
         self.PublicPath = PublicPath(identifier: identifier)!

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -892,15 +892,15 @@ pub contract HybridCustody {
     }
 
     init() {
-        let identifier = "HybridCustodyChild".concat(self.account.address.toString())
+        let identifier = "HybridCustodyChild_".concat(self.account.address.toString())
         self.ChildStoragePath = StoragePath(identifier: identifier)!
         self.ChildPrivatePath = PrivatePath(identifier: identifier)!
         self.ChildPublicPath = PublicPath(identifier: identifier)!
 
-        self.LinkedAccountPrivatePath = PrivatePath(identifier: "LinkedAccountPrivatePath".concat(identifier))!
-        self.BorrowableAccountPrivatePath = PrivatePath(identifier: "BorrowableAccountPrivatePath".concat(identifier))!
+        self.LinkedAccountPrivatePath = PrivatePath(identifier: "LinkedAccountPrivatePath_".concat(identifier))!
+        self.BorrowableAccountPrivatePath = PrivatePath(identifier: "BorrowableAccountPrivatePath_".concat(identifier))!
 
-        let managerIdentifier = "HybridCustodyManager".concat(self.account.address.toString())
+        let managerIdentifier = "HybridCustodyManager_".concat(self.account.address.toString())
         self.ManagerStoragePath = StoragePath(identifier: managerIdentifier)!
         self.ManagerPublicPath = PublicPath(identifier: managerIdentifier)!
         self.ManagerPrivatePath = PrivatePath(identifier: managerIdentifier)!

--- a/scripts/factory/get_supported_types_from_manager.cdc
+++ b/scripts/factory/get_supported_types_from_manager.cdc
@@ -1,0 +1,10 @@
+import "CapabilityFactory"
+
+import "NonFungibleToken"
+
+pub fun main(address: Address): [Type] {
+    let getterRef = getAccount(address).getCapability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)
+        .borrow()
+        ?? panic("CapabilityFactory Getter not found")
+    return getterRef.getSupportedTypes()
+}

--- a/scripts/test/add_nft_provider_factory.cdc
+++ b/scripts/test/add_nft_provider_factory.cdc
@@ -1,0 +1,20 @@
+import "CapabilityFactory"
+import "NFTCollectionPublicFactory"
+import "NFTProviderAndCollectionFactory"
+import "NFTProviderFactory"
+import "FTProviderFactory"
+
+import "NonFungibleToken"
+import "FungibleToken"
+
+pub fun main(address: Address): Bool {
+    
+    let managerRef = getAuthAccount(address).borrow<&CapabilityFactory.Manager>(from: CapabilityFactory.StoragePath)
+        ?? panic("CapabilityFactory Manager not found")
+    
+    let nftProviderFactory = NFTProviderFactory.Factory()
+    
+    managerRef.addFactory(Type<&{NonFungibleToken.Provider}>(), nftProviderFactory)
+
+    return true
+}

--- a/scripts/test/remove_nft_provider_factory.cdc
+++ b/scripts/test/remove_nft_provider_factory.cdc
@@ -8,9 +8,11 @@ pub fun main(address: Address): Bool {
     let managerRef = getAuthAccount(address).borrow<&CapabilityFactory.Manager>(from: CapabilityFactory.StoragePath)
         ?? panic("CapabilityFactory Manager not found")
     
-    let nftProviderFactory = NFTProviderFactory.Factory()
+    let expectedType = Type<NFTProviderFactory.Factory>()
     
-    managerRef.addFactory(Type<&{NonFungibleToken.Provider}>(), nftProviderFactory)
+    if let removed = managerRef.removeFactory(Type<&{NonFungibleToken.Provider}>()) {
+        return removed.getType() == expectedType
+    }
 
-    return true
+    return false
 }

--- a/scripts/test/update_nft_provider_factory.cdc
+++ b/scripts/test/update_nft_provider_factory.cdc
@@ -1,0 +1,14 @@
+import "CapabilityFactory"
+import "NFTProviderFactory"
+
+import "NonFungibleToken"
+
+pub fun main(address: Address) {
+    
+    let managerRef = getAuthAccount(address).borrow<&CapabilityFactory.Manager>(from: CapabilityFactory.StoragePath)
+        ?? panic("CapabilityFactory Manager not found")
+    
+    let nftProviderFactory = NFTProviderFactory.Factory()
+    
+    managerRef.updateFactory(Type<&{NonFungibleToken.Provider}>(), nftProviderFactory)
+}

--- a/test/CapabilityFactory_tests.cdc
+++ b/test/CapabilityFactory_tests.cdc
@@ -42,6 +42,18 @@ pub fun testUpdateNFTProviderFactory() {
     scriptExecutor("test/update_nft_provider_factory.cdc", [tmp.address])
 }
 
+pub fun testRemoveNFTProviderFactory() {
+    let tmp = blockchain.createAccount()
+    setupNFTCollection(tmp)
+
+    setupCapabilityFactoryManager(tmp)
+
+    assert(
+        (scriptExecutor("test/remove_nft_provider_factory.cdc", [tmp.address]) as! Bool?)!,
+        message: "Removing NFTProviderFactory failed"
+    )
+}
+
 // END SECTION - Test Cases
 
 pub fun setup() {

--- a/test/CapabilityFactory_tests.cdc
+++ b/test/CapabilityFactory_tests.cdc
@@ -20,6 +20,19 @@ pub fun testGetProviderCapability() {
     scriptExecutor("factory/get_nft_provider_from_factory.cdc", [signer.address])
 }
 
+pub fun testGetSupportedTypesFromManager() {
+    let tmp = blockchain.createAccount()
+    setupNFTCollection(tmp)
+
+    setupCapabilityFactoryManager(tmp)
+
+    let supportedTypes = (scriptExecutor("factory/get_supported_types_from_manager.cdc", [tmp.address]) as! [Type]?)!
+    assert(
+        supportedTypes.length == 4,
+        message: "Removing NFTProviderFactory failed"
+    )
+}
+
 pub fun testAddFactoryFails() {
     let tmp = blockchain.createAccount()
     setupNFTCollection(tmp)

--- a/transactions/factory/setup.cdc
+++ b/transactions/factory/setup.cdc
@@ -26,13 +26,6 @@ transaction {
 
         let manager = acct.borrow<&CapabilityFactory.Manager>(from: CapabilityFactory.StoragePath)
             ?? panic("manager not found")
-        
-        let factoryMapping = {
-            Type<&{NonFungibleToken.CollectionPublic}>(): NFTCollectionPublicFactory.Factory(),
-            Type<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(): NFTProviderAndCollectionFactory.Factory(),
-            Type<&{NonFungibleToken.Provider}>(): NFTProviderFactory.Factory(),
-            Type<&{FungibleToken.Provider}>(): FTProviderFactory.Factory()
-        }
 
         manager.updateFactory(Type<&{NonFungibleToken.CollectionPublic}>(), NFTCollectionPublicFactory.Factory())
         manager.updateFactory(Type<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(), NFTProviderAndCollectionFactory.Factory())

--- a/transactions/factory/setup.cdc
+++ b/transactions/factory/setup.cdc
@@ -27,10 +27,17 @@ transaction {
         let manager = acct.borrow<&CapabilityFactory.Manager>(from: CapabilityFactory.StoragePath)
             ?? panic("manager not found")
         
-        manager.addFactory(Type<&{NonFungibleToken.CollectionPublic}>(), NFTCollectionPublicFactory.Factory())
-        manager.addFactory(Type<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(), NFTProviderAndCollectionFactory.Factory())
-        manager.addFactory(Type<&{NonFungibleToken.Provider}>(), NFTProviderFactory.Factory())
-        manager.addFactory(Type<&{FungibleToken.Provider}>(), FTProviderFactory.Factory())
+        let factoryMapping = {
+            Type<&{NonFungibleToken.CollectionPublic}>(): NFTCollectionPublicFactory.Factory(),
+            Type<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(): NFTProviderAndCollectionFactory.Factory(),
+            Type<&{NonFungibleToken.Provider}>(): NFTProviderFactory.Factory(),
+            Type<&{FungibleToken.Provider}>(): FTProviderFactory.Factory()
+        }
+
+        manager.updateFactory(Type<&{NonFungibleToken.CollectionPublic}>(), NFTCollectionPublicFactory.Factory())
+        manager.updateFactory(Type<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(), NFTProviderAndCollectionFactory.Factory())
+        manager.updateFactory(Type<&{NonFungibleToken.Provider}>(), NFTProviderFactory.Factory())
+        manager.updateFactory(Type<&{FungibleToken.Provider}>(), FTProviderFactory.Factory())
     }
 }
  


### PR DESCRIPTION
Closes: #73 
Coverage: 75.6%

Added pre condition to `Manager.addFactory()` to prevent overwriting existing factories. Also added `Manager.updateFactory()` which overwrites Factories on given Type, and adds if it didn't already exist. The thought here is that the behavior is more explicit and provides a safer method to add new Factory types depending on developer preference, but open to feedback on this behavior.

Also added comments to CapabilityFactory contract.

Last note, I added a delimiter `'_'` to derived canonical paths between the prefix and deployment Address. I thought this would make it easier to split the strings should the need arise.