### PR TITLE
address outstanding TODOs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage.json
+.idea

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -67,6 +67,7 @@ pub contract HybridCustody {
         pub fun getOwner(): Address?
         pub fun getPendingOwner(): Address?
         access(contract) fun setOwnerCallback(_ addr: Address)
+        pub fun rotateAuthAccount()
     }
 
     // A ChildAccount shares the BorrowableAccount capability to itelf with ProxyAccount resources
@@ -301,6 +302,9 @@ pub contract HybridCustody {
 
             let acct = cap.borrow()
                 ?? panic("cannot add invalid account")
+
+            // for safety, rotate the auth account capability to prevent any outstanding capabilities from the previous owner
+            acct.rotateAuthAccount()
             self.ownedAccounts[cap.address] = cap
 
             emit OwnershipUpdated(id: acct.uuid, child: cap.address, previousOwner: acct.getOwner(), owner: self.owner!.address, active: true)

--- a/transactions/hybrid-custody/accept_ownership.cdc
+++ b/transactions/hybrid-custody/accept_ownership.cdc
@@ -1,3 +1,5 @@
+#allowAccountLinking
+
 import "HybridCustody"
 import "CapabilityFilter"
 import "MetadataViews"


### PR DESCRIPTION
Closes #74

1. Removes TODOs which (I think) have already been resolved
2. Handles a TODO about letting the owner of an account rotate the auth account capability
3. Leaves one TODO (happy to address in this PR) about how to handle publishing to a parent a second time.