### PR TITLE
add coverage for Manager.giveOwnership()

### DIFF
--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -360,10 +360,9 @@ pub contract HybridCustody {
             acct.setDisplay(display)
         }
 
-        pub fun giveOwnerShip(addr: Address, to: Address) {
+        pub fun giveOwnership(addr: Address, to: Address) {
             let acct = self.ownedAccounts.remove(key: addr)
                 ?? panic("account not found")
-            self.ownedAccounts.remove(key: acct.address)
 
             acct.borrow()!.giveOwnership(to: to)
         }

--- a/transactions/hybrid-custody/transfer_ownership_from_manager.cdc
+++ b/transactions/hybrid-custody/transfer_ownership_from_manager.cdc
@@ -1,0 +1,11 @@
+#allowAccountLinking
+
+import "HybridCustody"
+
+transaction(ownedAddress: Address, owner: Address) {
+    prepare(acct: AuthAccount) {
+        let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+            ?? panic("manager not found")
+        manager.giveOwnership(addr: ownedAddress, to: owner)
+    }
+}


### PR DESCRIPTION
Closes: #94 

Renaming from `Manager.giveOwnerShip()` to `Manager.giveOwnership()` and adding test coverage for the method.