### PR TITLE
remove references to old construct names

### DIFF
--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -550,8 +550,8 @@ pub contract HybridCustody {
 
         access(contract) fun setRedeemed(_ addr: Address) {
             let acct = self.childCap.borrow()!.borrowAccount()
-            if let m = acct.borrow<&OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) {
-                m.setRedeemed(addr)
+            if let o = acct.borrow<&OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) {
+                o.setRedeemed(addr)
             }
         }
 

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -27,9 +27,9 @@ Contributors (please add to this list if you contribute!):
 */
 pub contract HybridCustody {
 
-    pub let ChildStoragePath: StoragePath
-    pub let ChildPublicPath: PublicPath
-    pub let ChildPrivatePath: PrivatePath
+    pub let OwnedAccountStoragePath: StoragePath
+    pub let OwnedAccountPublicPath: PublicPath
+    pub let OwnedAccountPrivatePath: PrivatePath
 
     pub let ManagerStoragePath: StoragePath
     pub let ManagerPublicPath: PublicPath
@@ -550,7 +550,7 @@ pub contract HybridCustody {
 
         access(contract) fun setRedeemed(_ addr: Address) {
             let acct = self.childCap.borrow()!.borrowAccount()
-            if let m = acct.borrow<&OwnedAccount>(from: HybridCustody.ChildStoragePath) {
+            if let m = acct.borrow<&OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) {
                 m.setRedeemed(addr)
             }
         }
@@ -587,7 +587,7 @@ pub contract HybridCustody {
             }
 
             let acct = child.borrowAccount()
-            if let childAcct = acct.borrow<&OwnedAccount>(from: HybridCustody.ChildStoragePath) {
+            if let childAcct = acct.borrow<&OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) {
                 childAcct.removeParent(parent: parent)
             }
         }
@@ -726,7 +726,7 @@ pub contract HybridCustody {
             assert(delegator.check(), message: "failed to setup capability delegator for parent address")
 
             let borrowableCap = self.borrowAccount().getCapability<&{BorrowableAccount, OwnedAccountPublic, MetadataViews.Resolver}>(
-                HybridCustody.ChildPrivatePath
+                HybridCustody.OwnedAccountPrivatePath
             )
             let childAcct <- create ChildAccount(borrowableCap, factory, filter, delegator, parentAddress)
 
@@ -854,7 +854,7 @@ pub contract HybridCustody {
             let identifier =  HybridCustody.getOwnerIdentifier(to)
             let cap = acct.link<&{OwnedAccountPrivate, OwnedAccountPublic, MetadataViews.Resolver}>(
                     PrivatePath(identifier: identifier)!,
-                    target: HybridCustody.ChildStoragePath
+                    target: HybridCustody.OwnedAccountStoragePath
                 ) ?? panic("failed to link child account capability")
 
             acct.inbox.publish(cap, name: identifier, recipient: to)
@@ -1036,9 +1036,9 @@ pub contract HybridCustody {
 
     init() {
         let identifier = "HybridCustodyChild_".concat(self.account.address.toString())
-        self.ChildStoragePath = StoragePath(identifier: identifier)!
-        self.ChildPrivatePath = PrivatePath(identifier: identifier)!
-        self.ChildPublicPath = PublicPath(identifier: identifier)!
+        self.OwnedAccountStoragePath = StoragePath(identifier: identifier)!
+        self.OwnedAccountPrivatePath = PrivatePath(identifier: identifier)!
+        self.OwnedAccountPublicPath = PublicPath(identifier: identifier)!
 
         self.LinkedAccountPrivatePath = PrivatePath(identifier: "LinkedAccountPrivatePath_".concat(identifier))!
         self.BorrowableAccountPrivatePath = PrivatePath(identifier: "BorrowableAccountPrivatePath_".concat(identifier))!

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -233,7 +233,7 @@ pub contract HybridCustody {
         pub fun removeChild(addr: Address)
         pub fun removeOwned(addr: Address)
 
-        pub fun borrowOwnedAccount(addr: Address): &{OwnedAccountPrivate, OwnedAccountPublic}?
+        pub fun borrowOwnedAccount(addr: Address): &{OwnedAccountPrivate, OwnedAccountPublic, MetadataViews.Resolver}?
         pub fun setManagerCapabilityFilter(cap: Capability<&{CapabilityFilter.Filter}>?, childAddress: Address) {
             pre {
                 cap == nil || cap!.check(): "Invalid Manager Capability Filter"
@@ -362,7 +362,7 @@ pub contract HybridCustody {
             return cap!.borrow()
         }
 
-        pub fun borrowOwnedAccount(addr: Address): &{OwnedAccountPrivate, OwnedAccountPublic}? {
+        pub fun borrowOwnedAccount(addr: Address): &{OwnedAccountPrivate, OwnedAccountPublic, MetadataViews.Resolver}? {
             if let cap = self.ownedAccounts[addr] {
                 return cap.borrow()
             }

--- a/scripts/delegator/find_nft_collection_cap.cdc
+++ b/scripts/delegator/find_nft_collection_cap.cdc
@@ -6,14 +6,14 @@ import "ExampleNFT"
 pub fun main(addr: Address): Bool {
     let acct = getAccount(addr)
 
-    let proxy = 
+    let delegator = 
         acct.getCapability<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPublic}>(CapabilityDelegator.PublicPath).borrow()
-        ?? panic("could not borrow proxy")
+        ?? panic("could not borrow delegator")
 
     let desiredType = Type<Capability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic}>>()
-    let foundType = proxy.findFirstPublicType(desiredType) ?? panic("no type found")
+    let foundType = delegator.findFirstPublicType(desiredType) ?? panic("no type found")
     
-    let nakedCap = proxy.getPublicCapability(foundType) ?? panic("requested capability type was not found")
+    let nakedCap = delegator.getPublicCapability(foundType) ?? panic("requested capability type was not found")
 
     // we don't need to do anything with this cap, being able to cast here is enough to know
     // that this works

--- a/scripts/delegator/find_nft_provider_cap.cdc
+++ b/scripts/delegator/find_nft_provider_cap.cdc
@@ -6,14 +6,14 @@ import "ExampleNFT"
 pub fun main(addr: Address): Bool {
     let acct = getAuthAccount(addr)
 
-    let proxy = 
+    let delegator = 
         acct.getCapability<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPrivate}>(CapabilityDelegator.PrivatePath).borrow()
-        ?? panic("could not borrow proxy")
+        ?? panic("could not borrow delegator")
 
     let desiredType = Type<Capability<&ExampleNFT.Collection{NonFungibleToken.Provider}>>()
-    let foundType = proxy.findFirstPrivateType(desiredType) ?? panic("no type found")
+    let foundType = delegator.findFirstPrivateType(desiredType) ?? panic("no type found")
     
-    let nakedCap = proxy.getPrivateCapability(foundType) ?? panic("requested capability type was not found")
+    let nakedCap = delegator.getPrivateCapability(foundType) ?? panic("requested capability type was not found")
 
     // we don't need to do anything with this cap, being able to cast here is enough to know
     // that this works

--- a/scripts/delegator/get_all_private_caps.cdc
+++ b/scripts/delegator/get_all_private_caps.cdc
@@ -7,7 +7,7 @@ pub fun main(address: Address): Bool {
     let privateCaps: [Capability] = getAuthAccount(address).getCapability<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPrivate}>(CapabilityDelegator.PrivatePath)
         .borrow()
         ?.getAllPrivate()
-        ?? panic("could not borrow proxy")
+        ?? panic("could not borrow delegator")
 
     let desiredType: Type = Type<Capability<&ExampleNFT.Collection{NonFungibleToken.Provider}>>()
 

--- a/scripts/delegator/get_all_public_caps.cdc
+++ b/scripts/delegator/get_all_public_caps.cdc
@@ -4,9 +4,9 @@ import "NonFungibleToken"
 import "ExampleNFT"
 
 pub fun main(address: Address): Bool {
-    let proxy = getAccount(address).getCapability<&{CapabilityDelegator.GetterPublic}>(CapabilityDelegator.PublicPath).borrow()
-        ?? panic("proxy not found")
-    let publicCaps: [Capability] = proxy.getAllPublic()
+    let delegator = getAccount(address).getCapability<&{CapabilityDelegator.GetterPublic}>(CapabilityDelegator.PublicPath).borrow()
+        ?? panic("delegator not found")
+    let publicCaps: [Capability] = delegator.getAllPublic()
     assert(publicCaps.length > 0, message: "no public capabilities found")
     
     let desiredType: Type = Type<Capability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>>()

--- a/scripts/delegator/get_nft_collection.cdc
+++ b/scripts/delegator/get_nft_collection.cdc
@@ -6,12 +6,12 @@ import "ExampleNFT"
 pub fun main(addr: Address): Bool {
     let acct = getAccount(addr)
 
-    let proxy = 
+    let delegator = 
         acct.getCapability<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPublic}>(CapabilityDelegator.PublicPath).borrow()
-        ?? panic("could not borrow proxy")
+        ?? panic("could not borrow delegator")
 
     let capType = Type<Capability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>>()
-    let nakedCap = proxy.getPublicCapability(capType) ?? panic("requested capability type was not found")
+    let nakedCap = delegator.getPublicCapability(capType) ?? panic("requested capability type was not found")
 
     // we don't need to do anything with this cap, being able to cast here is enough to know
     // that this works

--- a/scripts/delegator/get_nft_provider.cdc
+++ b/scripts/delegator/get_nft_provider.cdc
@@ -6,12 +6,12 @@ import "ExampleNFT"
 pub fun main(addr: Address): Bool {
     let acct = getAuthAccount(addr)
 
-    let proxy = 
+    let delegator = 
         acct.getCapability<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPrivate}>(CapabilityDelegator.PrivatePath).borrow()
-        ?? panic("could not borrow proxy")
+        ?? panic("could not borrow delegator")
 
     let capType = Type<Capability<&ExampleNFT.Collection{NonFungibleToken.Provider}>>()
-    let nakedCap = proxy.getPrivateCapability(capType) ?? panic("requested capability type was not found")
+    let nakedCap = delegator.getPrivateCapability(capType) ?? panic("requested capability type was not found")
 
     // we don't need to do anything with this cap, being able to cast here is enough to know
     // that this works

--- a/scripts/hybrid-custody/get_owner_of_child.cdc
+++ b/scripts/hybrid-custody/get_owner_of_child.cdc
@@ -2,8 +2,8 @@ import "HybridCustody"
 
 pub fun main(addr: Address): Address? {
     let acct = getAuthAccount(addr)
-    let c = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+    let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
         ?? panic("owned account missing")
     
-    return c.getOwner()
+    return o.getOwner()
 }

--- a/scripts/hybrid-custody/get_owner_of_child.cdc
+++ b/scripts/hybrid-custody/get_owner_of_child.cdc
@@ -2,7 +2,7 @@ import "HybridCustody"
 
 pub fun main(addr: Address): Address? {
     let acct = getAuthAccount(addr)
-    let c = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
+    let c = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
         ?? panic("owned account missing")
     
     return c.getOwner()

--- a/scripts/hybrid-custody/get_parent_addresses.cdc
+++ b/scripts/hybrid-custody/get_parent_addresses.cdc
@@ -2,7 +2,7 @@ import "HybridCustody"
 
 pub fun main(child: Address): [Address] {
     let acct = getAuthAccount(child)
-    let m = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+    let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
         ?? panic("owned account not found")
-    return  m.getParentsAddresses() 
+    return  o.getParentsAddresses() 
 }

--- a/scripts/hybrid-custody/get_parent_addresses.cdc
+++ b/scripts/hybrid-custody/get_parent_addresses.cdc
@@ -2,7 +2,7 @@ import "HybridCustody"
 
 pub fun main(child: Address): [Address] {
     let acct = getAuthAccount(child)
-    let m = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
-        ?? panic("child account not found")
+    let m = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+        ?? panic("owned account not found")
     return  m.getParentsAddresses() 
 }

--- a/scripts/hybrid-custody/get_parents_from_child.cdc
+++ b/scripts/hybrid-custody/get_parents_from_child.cdc
@@ -2,8 +2,8 @@ import "HybridCustody"
 
 pub fun main(child: Address): {Address: Bool} {
     let acct = getAuthAccount(child)
-    let m = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
-        ?? panic("child account not found")
+    let m = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+        ?? panic("owned account not found")
 
     return m.getParentStatuses()
 }

--- a/scripts/hybrid-custody/get_parents_from_child.cdc
+++ b/scripts/hybrid-custody/get_parents_from_child.cdc
@@ -2,8 +2,8 @@ import "HybridCustody"
 
 pub fun main(child: Address): {Address: Bool} {
     let acct = getAuthAccount(child)
-    let m = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+    let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
         ?? panic("owned account not found")
 
-    return m.getParentStatuses()
+    return o.getParentStatuses()
 }

--- a/scripts/hybrid-custody/get_pending_owner_of_child.cdc
+++ b/scripts/hybrid-custody/get_pending_owner_of_child.cdc
@@ -2,8 +2,8 @@ import "HybridCustody"
 
 pub fun main(addr: Address): Address? {
     let acct = getAuthAccount(addr)
-    let c = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+    let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
         ?? panic("owned account missing")
     
-    return c.getPendingOwner()
+    return o.getPendingOwner()
 }

--- a/scripts/hybrid-custody/get_pending_owner_of_child.cdc
+++ b/scripts/hybrid-custody/get_pending_owner_of_child.cdc
@@ -2,7 +2,7 @@ import "HybridCustody"
 
 pub fun main(addr: Address): Address? {
     let acct = getAuthAccount(addr)
-    let c = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
+    let c = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
         ?? panic("owned account missing")
     
     return c.getPendingOwner()

--- a/scripts/hybrid-custody/is_parent.cdc
+++ b/scripts/hybrid-custody/is_parent.cdc
@@ -2,8 +2,8 @@ import "HybridCustody"
 
 pub fun main(child: Address, parent: Address): Bool {
     let acct = getAuthAccount(child)
-    let m = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
-        ?? panic("child account not found")
+    let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+        ?? panic("owned account not found")
 
-    return m.isChildOf(parent)
+    return owned.isChildOf(parent)
 }

--- a/scripts/hybrid-custody/is_redeemed.cdc
+++ b/scripts/hybrid-custody/is_redeemed.cdc
@@ -2,8 +2,8 @@ import "HybridCustody"
 
 pub fun main(child: Address, parent: Address): Bool {
     let acct = getAuthAccount(child)
-    let m = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
-        ?? panic("child account not found")
+    let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+        ?? panic("owned account not found")
 
-    return m.getRedeemedStatus(addr: parent) ?? panic("no status found")
+    return owned.getRedeemedStatus(addr: parent) ?? panic("no status found")
 }

--- a/scripts/hybrid-custody/metadata/assert_owned_account_display.cdc
+++ b/scripts/hybrid-custody/metadata/assert_owned_account_display.cdc
@@ -3,9 +3,9 @@ import "MetadataViews"
 
 pub fun main(addr: Address, name: String, desc: String, thumbnail: String): Bool {
     let acct = getAuthAccount(addr)
-    let child = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
-        ?? panic("no child account found")
-    let display = child.resolveView(Type<MetadataViews.Display>())! as! MetadataViews.Display
+    let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+        ?? panic("no owned account found")
+    let display = owned.resolveView(Type<MetadataViews.Display>())! as! MetadataViews.Display
 
     assert(display.name == name, message: "names do not match")
     assert(display.description == desc, message: "descriptions do not match")

--- a/scripts/hybrid-custody/metadata/resolve_owned_display_name.cdc
+++ b/scripts/hybrid-custody/metadata/resolve_owned_display_name.cdc
@@ -3,9 +3,9 @@ import "MetadataViews"
 
 pub fun main(child: Address): String {
     let acct = getAuthAccount(child)
-    let c = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
-            ?? panic("child account not found")
+    let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+            ?? panic("owned account not found")
     
-    let d = c.resolveView(Type<MetadataViews.Display>())! as! MetadataViews.Display
+    let d = o.resolveView(Type<MetadataViews.Display>())! as! MetadataViews.Display
     return d.name
 }

--- a/scripts/test/test_get_accessible_child_nfts.cdc
+++ b/scripts/test/test_get_accessible_child_nfts.cdc
@@ -5,7 +5,7 @@ import "StringUtils"
 
 /* 
  * TEST SCRIPT
- * This script is a replication of that found in hybrid-custody/get_accessible_proxy_nfts.cdc as it's the best as
+ * This script is a replication of that found in hybrid-custody/get_accessible_child_account_nfts.cdc as it's the best as
  * as can be done without accessing the script's return type in the Cadence testing framework
  */
 

--- a/test/CapabilityFactory_tests.cdc
+++ b/test/CapabilityFactory_tests.cdc
@@ -271,7 +271,7 @@ pub fun range(_ start: Int, _ end: Int): [Int]{
 
 // BEGIN SECTION - transactions used in tests
 pub fun sharePublicExampleNFT(_ acct: Test.Account) {
-    let txCode = loadCode("proxy/add_public_nft_collection.cdc", "transactions")
+    let txCode = loadCode("delegator/add_public_nft_collection.cdc", "transactions")
     txExecutor(txCode, [acct], [], nil, nil)
 }
 
@@ -299,14 +299,14 @@ pub fun setupCapabilityFactoryManager(_ acct: Test.Account) {
 
 // BEGIN SECTION - scripts used in tests
 
-pub fun getExampleNFTCollectionFromProxy(_ owner: Test.Account) {
-    let borrowed = scriptExecutor("proxy/get_nft_collection.cdc", [owner.address])! as! Bool
-    assert(borrowed, message: "failed to borrow proxy")
+pub fun getExampleNFTCollectionFromDelegator(_ owner: Test.Account) {
+    let borrowed = scriptExecutor("delegator/get_nft_collection.cdc", [owner.address])! as! Bool
+    assert(borrowed, message: "failed to borrow delegator")
 }
 
 pub fun findExampleNFTCollectionType(_ owner: Test.Account) {
-    let borrowed = scriptExecutor("proxy/find_nft_collection_cap.cdc", [owner.address])! as! Bool
-    assert(borrowed, message: "failed to borrow proxy")
+    let borrowed = scriptExecutor("delegator/find_nft_collection_cap.cdc", [owner.address])! as! Bool
+    assert(borrowed, message: "failed to borrow delegator")
 }
 
 pub fun expectScriptFailure(_ scriptName: String, _ arguments: [AnyStruct]): String {

--- a/transactions/delegator/add_private_nft_collection.cdc
+++ b/transactions/delegator/add_private_nft_collection.cdc
@@ -6,13 +6,13 @@ import "ExampleNFT"
 
 transaction {
     prepare(acct: AuthAccount) {
-        let child = acct.borrow<&CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath)
-            ?? panic("child not found")
+        let delegator = acct.borrow<&CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath)
+            ?? panic("delegator not found")
         
         let d = ExampleNFT.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
         
         let sharedCap = acct.getCapability<&ExampleNFT.Collection{NonFungibleToken.Provider}>(d.providerPath)
         
-        child.addCapability(cap: sharedCap, isPublic: false)
+        delegator.addCapability(cap: sharedCap, isPublic: false)
     }
 }

--- a/transactions/delegator/add_public_nft_collection.cdc
+++ b/transactions/delegator/add_public_nft_collection.cdc
@@ -5,11 +5,11 @@ import "ExampleNFT"
 
 transaction {
     prepare(acct: AuthAccount) {
-        let child = acct.borrow<&CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath)
-            ?? panic("child not found")
+        let delegator = acct.borrow<&CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath)
+            ?? panic("delegator not found")
 
         let sharedCap 
             = acct.getCapability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>(ExampleNFT.CollectionPublicPath)
-        child.addCapability(cap: sharedCap, isPublic: true)
+        delegator.addCapability(cap: sharedCap, isPublic: true)
     }
 }

--- a/transactions/delegator/setup.cdc
+++ b/transactions/delegator/setup.cdc
@@ -3,8 +3,8 @@ import "CapabilityDelegator"
 transaction {
     prepare(acct: AuthAccount) {
         if acct.borrow<&CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath) == nil {
-            let proxy <- CapabilityDelegator.createDelegator()
-            acct.save(<-proxy, to: CapabilityDelegator.StoragePath)
+            let delegator <- CapabilityDelegator.createDelegator()
+            acct.save(<-delegator, to: CapabilityDelegator.StoragePath)
         }
 
         acct.unlink(CapabilityDelegator.PublicPath)

--- a/transactions/hybrid-custody/accept_ownership.cdc
+++ b/transactions/hybrid-custody/accept_ownership.cdc
@@ -24,7 +24,7 @@ transaction(childAddress: Address, filterAddress: Address?, filterPath: PublicPa
 
         let inboxName = HybridCustody.getOwnerIdentifier(acct.address) 
         let cap = acct.inbox.claim<&AnyResource{HybridCustody.OwnedAccountPrivate, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(inboxName, provider: childAddress)
-            ?? panic("child account cap not found")
+            ?? panic("owned account cap not found")
 
         let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager no found")

--- a/transactions/hybrid-custody/add_example_nft2_collection_to_delegator.cdc
+++ b/transactions/hybrid-custody/add_example_nft2_collection_to_delegator.cdc
@@ -6,15 +6,15 @@ import "ExampleNFT2"
 
 transaction(parent: Address, isPublic: Bool) {
     prepare(acct: AuthAccount) {
-        let c = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
+        let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("owned account not found")
-        let child = c.borrowChildAccount(parent: parent)
+        let child = o.borrowChildAccount(parent: parent)
             ?? panic("child account not found")
 
         let path = /private/exampleNFT2FullCollection
         acct.link<&ExampleNFT2.Collection>(path, target: ExampleNFT2.CollectionStoragePath)
         let cap = acct.getCapability<&ExampleNFT2.Collection>(path)
 
-        c.addCapabilityToDelegator(parent: parent, cap: cap, isPublic: isPublic)
+        o.addCapabilityToDelegator(parent: parent, cap: cap, isPublic: isPublic)
     }
 }

--- a/transactions/hybrid-custody/add_example_nft_collection_to_delegator.cdc
+++ b/transactions/hybrid-custody/add_example_nft_collection_to_delegator.cdc
@@ -6,15 +6,15 @@ import "ExampleNFT"
 
 transaction(parent: Address, isPublic: Bool) {
     prepare(acct: AuthAccount) {
-        let c = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
+        let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("owned account not found")
-        let child: &HybridCustody.ChildAccount = c.borrowChildAccount(parent: parent)
+        let child: &HybridCustody.ChildAccount = o.borrowChildAccount(parent: parent)
             ?? panic("child account not found")
 
         let path = /private/exampleNFTFullCollection
         acct.link<&ExampleNFT.Collection>(path, target: ExampleNFT.CollectionStoragePath)
         let cap = acct.getCapability<&ExampleNFT.Collection>(path)
 
-        c.addCapabilityToDelegator(parent: parent, cap: cap, isPublic: isPublic)
+        o.addCapabilityToDelegator(parent: parent, cap: cap, isPublic: isPublic)
     }
 }

--- a/transactions/hybrid-custody/metadata/set_owned_account_display.cdc
+++ b/transactions/hybrid-custody/metadata/set_owned_account_display.cdc
@@ -3,7 +3,7 @@ import "MetadataViews"
 
 transaction(name: String, description: String, thumbnail: String) {
     prepare(acct: AuthAccount) {
-        let a = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
+        let a = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("account not found")
         
         let d = MetadataViews.Display(

--- a/transactions/hybrid-custody/metadata/set_owned_account_display.cdc
+++ b/transactions/hybrid-custody/metadata/set_owned_account_display.cdc
@@ -3,7 +3,7 @@ import "MetadataViews"
 
 transaction(name: String, description: String, thumbnail: String) {
     prepare(acct: AuthAccount) {
-        let a = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+        let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("account not found")
         
         let d = MetadataViews.Display(
@@ -12,7 +12,7 @@ transaction(name: String, description: String, thumbnail: String) {
             thumbnail: MetadataViews.HTTPFile(url: thumbnail)
         )
 
-        a.setDisplay(d)
+        o.setDisplay(d)
     }
 }
  

--- a/transactions/hybrid-custody/onboarding/blockchain_native.cdc
+++ b/transactions/hybrid-custody/onboarding/blockchain_native.cdc
@@ -79,7 +79,7 @@ transaction(
             )
 
         // Get a reference to the OwnedAccount resource
-        let child = newAccount.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)!
+        let owned = newAccount.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)!
 
         // Get the CapabilityFactory.Manager Capability
         let factory = getAccount(factoryAddress)
@@ -93,7 +93,7 @@ transaction(
         assert(filter.check(), message: "capability filter is not configured properly")
 
         // Configure access for the delegatee parent account
-        child.publishToParent(parentAddress: parent.address, factory: factory, filter: filter)
+        owned.publishToParent(parentAddress: parent.address, factory: factory, filter: filter)
 
         /* --- Add delegation to parent account --- */
         //

--- a/transactions/hybrid-custody/onboarding/blockchain_native.cdc
+++ b/transactions/hybrid-custody/onboarding/blockchain_native.cdc
@@ -66,20 +66,20 @@ transaction(
 
         // Create a OwnedAccount & link Capabilities
         let OwnedAccount <- HybridCustody.createChildAccount(acct: acctCap)
-        newAccount.save(<-OwnedAccount, to: HybridCustody.ChildStoragePath)
+        newAccount.save(<-OwnedAccount, to: HybridCustody.OwnedAccountStoragePath)
         newAccount
             .link<&HybridCustody.OwnedAccount{HybridCustody.BorrowableAccount, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(
-                HybridCustody.ChildPrivatePath,
-                target: HybridCustody.ChildStoragePath
+                HybridCustody.OwnedAccountPrivatePath,
+                target: HybridCustody.OwnedAccountStoragePath
             )
         newAccount
             .link<&HybridCustody.OwnedAccount{HybridCustody.OwnedAccountPublic}>(
-                HybridCustody.ChildPublicPath, 
-                target: HybridCustody.ChildStoragePath
+                HybridCustody.OwnedAccountPublicPath, 
+                target: HybridCustody.OwnedAccountStoragePath
             )
 
         // Get a reference to the OwnedAccount resource
-        let child = newAccount.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)!
+        let child = newAccount.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)!
 
         // Get the CapabilityFactory.Manager Capability
         let factory = getAccount(factoryAddress)

--- a/transactions/hybrid-custody/publish_to_parent.cdc
+++ b/transactions/hybrid-custody/publish_to_parent.cdc
@@ -5,8 +5,8 @@ import "CapabilityDelegator"
 
 transaction(parent: Address, factoryAddress: Address, filterAddress: Address) {
     prepare(acct: AuthAccount) {
-        let child = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
-            ?? panic("child account not found")
+        let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+            ?? panic("owned account not found")
 
         let factory = getAccount(factoryAddress).getCapability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)
         assert(factory.check(), message: "factory address is not configured properly")
@@ -14,6 +14,6 @@ transaction(parent: Address, factoryAddress: Address, filterAddress: Address) {
         let filter = getAccount(filterAddress).getCapability<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
         assert(filter.check(), message: "capability filter is not configured properly")
 
-        child.publishToParent(parentAddress: parent, factory: factory, filter: filter)
+        owned.publishToParent(parentAddress: parent, factory: factory, filter: filter)
     }
 }

--- a/transactions/hybrid-custody/relinquish_ownership.cdc
+++ b/transactions/hybrid-custody/relinquish_ownership.cdc
@@ -4,8 +4,8 @@ import "HybridCustody"
 
 transaction {
     prepare(acct: AuthAccount) {
-        let c = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
-            ?? panic("child not found")
-        c.seal()
+        let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+            ?? panic("owned not found")
+        owned.seal()
     }
 }

--- a/transactions/hybrid-custody/remove_parent_from_child.cdc
+++ b/transactions/hybrid-custody/remove_parent_from_child.cdc
@@ -2,10 +2,10 @@ import "HybridCustody"
 
 transaction(parent: Address) {
     prepare(acct: AuthAccount) {
-        let child = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
-            ?? panic("child not found")
+        let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+            ?? panic("owned not found")
 
-        child.removeParent(parent: parent)
+        owned.removeParent(parent: parent)
 
         let manager = getAccount(parent).getCapability<&HybridCustody.Manager{HybridCustody.ManagerPublic}>(HybridCustody.ManagerPublicPath)
             .borrow() ?? panic("manager not found")

--- a/transactions/hybrid-custody/setup_multi_sig.cdc
+++ b/transactions/hybrid-custody/setup_multi_sig.cdc
@@ -16,17 +16,17 @@ transaction(parentFilterAddress: Address?, childAccountFactoryAddress: Address, 
             acctCap = childAcct.linkAccount(HybridCustody.LinkedAccountPrivatePath)!
         }
 
-        if childAcct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath) == nil {
+        if childAcct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) == nil {
             let OwnedAccount <- HybridCustody.createChildAccount(acct: acctCap)
-            childAcct.save(<-OwnedAccount, to: HybridCustody.ChildStoragePath)
+            childAcct.save(<-OwnedAccount, to: HybridCustody.OwnedAccountStoragePath)
         }
 
         // check that paths are all configured properly
-        childAcct.unlink(HybridCustody.ChildPrivatePath)
-        childAcct.link<&HybridCustody.OwnedAccount{HybridCustody.BorrowableAccount, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.ChildPrivatePath, target: HybridCustody.ChildStoragePath)
+        childAcct.unlink(HybridCustody.OwnedAccountPrivatePath)
+        childAcct.link<&HybridCustody.OwnedAccount{HybridCustody.BorrowableAccount, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.OwnedAccountPrivatePath, target: HybridCustody.OwnedAccountStoragePath)
 
-        childAcct.unlink(HybridCustody.ChildPublicPath)
-        childAcct.link<&HybridCustody.OwnedAccount{HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.ChildPublicPath, target: HybridCustody.ChildStoragePath)
+        childAcct.unlink(HybridCustody.OwnedAccountPublicPath)
+        childAcct.link<&HybridCustody.OwnedAccount{HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.OwnedAccountPublicPath, target: HybridCustody.OwnedAccountStoragePath)
 
         // --------------------- Begin setup of child account ---------------------
 
@@ -44,21 +44,21 @@ transaction(parentFilterAddress: Address?, childAccountFactoryAddress: Address, 
         parentAcct.unlink(HybridCustody.ManagerPublicPath)
         parentAcct.unlink(HybridCustody.ManagerPrivatePath)
 
-        parentAcct.link<&HybridCustody.Manager{HybridCustody.ManagerPrivate, HybridCustody.ManagerPublic}>(HybridCustody.ChildPrivatePath, target: HybridCustody.ManagerStoragePath)
-        parentAcct.link<&HybridCustody.Manager{HybridCustody.ManagerPublic}>(HybridCustody.ChildPublicPath, target: HybridCustody.ManagerStoragePath)
+        parentAcct.link<&HybridCustody.Manager{HybridCustody.ManagerPrivate, HybridCustody.ManagerPublic}>(HybridCustody.OwnedAccountPrivatePath, target: HybridCustody.ManagerStoragePath)
+        parentAcct.link<&HybridCustody.Manager{HybridCustody.ManagerPublic}>(HybridCustody.OwnedAccountPublicPath, target: HybridCustody.ManagerStoragePath)
         // --------------------- End setup of parent account ---------------------
 
         // Publish account to parent
-        let child = childAcct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
+        let child = childAcct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("child account not found")
 
         let factory = getAccount(childAccountFactoryAddress).getCapability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)
         assert(factory.check(), message: "factory address is not configured properly")
 
-        let filterForProxy = getAccount(childAccountFilterAddress).getCapability<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
-        assert(filterForProxy.check(), message: "capability filter is not configured properly")
+        let filterForChild = getAccount(childAccountFilterAddress).getCapability<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+        assert(filterForChild.check(), message: "capability filter is not configured properly")
 
-        child.publishToParent(parentAddress: parentAcct.address, factory: factory, filter: filterForProxy)
+        child.publishToParent(parentAddress: parentAcct.address, factory: factory, filter: filterForChild)
 
         // claim the account on the parent
         let inboxName = HybridCustody.getChildAccountIdentifier(parentAcct.address)

--- a/transactions/hybrid-custody/setup_multi_sig.cdc
+++ b/transactions/hybrid-custody/setup_multi_sig.cdc
@@ -49,8 +49,8 @@ transaction(parentFilterAddress: Address?, childAccountFactoryAddress: Address, 
         // --------------------- End setup of parent account ---------------------
 
         // Publish account to parent
-        let child = childAcct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
-            ?? panic("child account not found")
+        let owned = childAcct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+            ?? panic("owned account not found")
 
         let factory = getAccount(childAccountFactoryAddress).getCapability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)
         assert(factory.check(), message: "factory address is not configured properly")
@@ -58,7 +58,7 @@ transaction(parentFilterAddress: Address?, childAccountFactoryAddress: Address, 
         let filterForChild = getAccount(childAccountFilterAddress).getCapability<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
         assert(filterForChild.check(), message: "capability filter is not configured properly")
 
-        child.publishToParent(parentAddress: parentAcct.address, factory: factory, filter: filterForChild)
+        owned.publishToParent(parentAddress: parentAcct.address, factory: factory, filter: filterForChild)
 
         // claim the account on the parent
         let inboxName = HybridCustody.getChildAccountIdentifier(parentAcct.address)

--- a/transactions/hybrid-custody/setup_owned_account.cdc
+++ b/transactions/hybrid-custody/setup_owned_account.cdc
@@ -15,17 +15,17 @@ transaction {
             acctCap = acct.linkAccount(HybridCustody.LinkedAccountPrivatePath)!
         }
 
-        if acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath) == nil {
+        if acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) == nil {
             let OwnedAccount <- HybridCustody.createChildAccount(acct: acctCap)
-            acct.save(<-OwnedAccount, to: HybridCustody.ChildStoragePath)
+            acct.save(<-OwnedAccount, to: HybridCustody.OwnedAccountStoragePath)
         }
 
         // check that paths are all configured properly
-        acct.unlink(HybridCustody.ChildPrivatePath)
-        acct.link<&HybridCustody.OwnedAccount{HybridCustody.BorrowableAccount, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.ChildPrivatePath, target: HybridCustody.ChildStoragePath)
+        acct.unlink(HybridCustody.OwnedAccountPrivatePath)
+        acct.link<&HybridCustody.OwnedAccount{HybridCustody.BorrowableAccount, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.OwnedAccountPrivatePath, target: HybridCustody.OwnedAccountStoragePath)
 
-        acct.unlink(HybridCustody.ChildPublicPath)
-        acct.link<&HybridCustody.OwnedAccount{HybridCustody.OwnedAccountPublic}>(HybridCustody.ChildPublicPath, target: HybridCustody.ChildStoragePath)
+        acct.unlink(HybridCustody.OwnedAccountPublicPath)
+        acct.link<&HybridCustody.OwnedAccount{HybridCustody.OwnedAccountPublic}>(HybridCustody.OwnedAccountPublicPath, target: HybridCustody.OwnedAccountStoragePath)
     }
 }
  

--- a/transactions/hybrid-custody/setup_owned_account_with_display.cdc
+++ b/transactions/hybrid-custody/setup_owned_account_with_display.cdc
@@ -15,19 +15,19 @@ transaction(name: String, desc: String, thumbnailURL: String) {
             acctCap = acct.linkAccount(HybridCustody.LinkedAccountPrivatePath)!
         }
 
-        if acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath) == nil {
+        if acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) == nil {
             let OwnedAccount <- HybridCustody.createChildAccount(acct: acctCap)
-            acct.save(<-OwnedAccount, to: HybridCustody.ChildStoragePath)
+            acct.save(<-OwnedAccount, to: HybridCustody.OwnedAccountStoragePath)
         }
 
         // check that paths are all configured properly
-        acct.unlink(HybridCustody.ChildPrivatePath)
-        acct.link<&HybridCustody.OwnedAccount{HybridCustody.BorrowableAccount, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.ChildPrivatePath, target: HybridCustody.ChildStoragePath)
+        acct.unlink(HybridCustody.OwnedAccountPrivatePath)
+        acct.link<&HybridCustody.OwnedAccount{HybridCustody.BorrowableAccount, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.OwnedAccountPrivatePath, target: HybridCustody.OwnedAccountStoragePath)
 
-        acct.unlink(HybridCustody.ChildPublicPath)
-        acct.link<&HybridCustody.OwnedAccount{HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.ChildPublicPath, target: HybridCustody.ChildStoragePath)
+        acct.unlink(HybridCustody.OwnedAccountPublicPath)
+        acct.link<&HybridCustody.OwnedAccount{HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.OwnedAccountPublicPath, target: HybridCustody.OwnedAccountStoragePath)
 
-        let child = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)!
+        let child = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)!
 
         let thumbnail = MetadataViews.HTTPFile(url: thumbnailURL)
         let display = MetadataViews.Display(name: name, description: desc, thumbnail: thumbnail)

--- a/transactions/hybrid-custody/setup_owned_account_with_display.cdc
+++ b/transactions/hybrid-custody/setup_owned_account_with_display.cdc
@@ -27,11 +27,11 @@ transaction(name: String, desc: String, thumbnailURL: String) {
         acct.unlink(HybridCustody.OwnedAccountPublicPath)
         acct.link<&HybridCustody.OwnedAccount{HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.OwnedAccountPublicPath, target: HybridCustody.OwnedAccountStoragePath)
 
-        let child = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)!
+        let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)!
 
         let thumbnail = MetadataViews.HTTPFile(url: thumbnailURL)
         let display = MetadataViews.Display(name: name, description: desc, thumbnail: thumbnail)
-        child.setDisplay(display)
+        owned.setDisplay(display)
     }
 }
  

--- a/transactions/hybrid-custody/transfer_ownership.cdc
+++ b/transactions/hybrid-custody/transfer_ownership.cdc
@@ -4,8 +4,8 @@ import "HybridCustody"
 
 transaction(owner: Address) {
     prepare(acct: AuthAccount) {
-        let c = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
-            ?? panic("child not found")
-        c.giveOwnership(to: owner)
+        let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+            ?? panic("owned not found")
+        owned.giveOwnership(to: owner)
     }
 }


### PR DESCRIPTION
Closes: #72 #98
Coverage: 76.2%


Cleaning up instances of old construct and directory names after rename refactor in #97 