### PR TITLE
transaction sample for sharing ownership

### DIFF
--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -325,7 +325,7 @@ pub contract HybridCustody {
             self.childAccounts.remove(key: child)
         }
 
-        pub fun addOwnedAccount(cap: Capability<&{OwnedAccountPrivate, OwnedAccountPublic, MetadataViews.Resolver}>) {
+        pub fun addOwnedAccount(cap: Capability<&{OwnedAccountPrivate, OwnedAccountPublic, MetadataViews.Resolver}>, rotateAuthAcct: Bool, revokeKeys: Bool) {
             pre {
                 self.ownedAccounts[cap.address] == nil: "There is already a child account with this address"
             }
@@ -333,10 +333,15 @@ pub contract HybridCustody {
             let acct = cap.borrow()
                 ?? panic("cannot add invalid account")
 
-            // for safety, rotate the auth account capability to prevent any outstanding capabilities from the previous owner
-            // and revoke all outstanding keys.
-            acct.rotateAuthAccount()
-            acct.revokeAllKeys()
+            if rotateAuthAcct {
+                // for safety, rotate the auth account capability to prevent any outstanding capabilities from the previous owner
+                // and revoke all outstanding keys.
+                acct.rotateAuthAccount()
+            }
+
+            if revokeKeys {
+                acct.revokeAllKeys()
+            }
 
             self.ownedAccounts[cap.address] = cap
 

--- a/transactions/hybrid-custody/accept_ownership.cdc
+++ b/transactions/hybrid-custody/accept_ownership.cdc
@@ -29,6 +29,6 @@ transaction(childAddress: Address, filterAddress: Address?, filterPath: PublicPa
         let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager no found")
 
-        manager.addOwnedAccount(cap: cap)
+        manager.addOwnedAccount(cap: cap, rotateAuthAcct: true, revokeKeys: true)
     }
 }

--- a/transactions/hybrid-custody/share_ownership.cdc
+++ b/transactions/hybrid-custody/share_ownership.cdc
@@ -1,0 +1,22 @@
+import "HybridCustody"
+import "MetadataViews"
+
+// This transaction demonstrates how you can share ownership of one account with another, giving the receiving
+// account administrative access to the account being shared without revoking keys or removing access from the originating account.
+// This is especailly useful if you want to manage accounts from one central place, but still want to be able to do things
+// like sign in 
+transaction(shareWith: Address) {
+    prepare(acct: AuthAccount) {
+        let ownedAccount = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.ChildStoragePath)
+            ?? panic("no owned account found")
+
+        let identifier = HybridCustody.getOwnerIdentifier(shareWith)
+        let path = PrivatePath(identifier: identifier)!
+
+        acct.link<&{HybridCustody.OwnedAccountPrivate, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(path, target: HybridCustody.ChildStoragePath)
+        let cap = acct.getCapability<&{HybridCustody.OwnedAccountPrivate, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(path)
+        assert(cap.check(), message: "owned account capability check failed")
+
+        acct.inbox.publish(cap, name: identifier, recipient: shareWith)
+    }
+}


### PR DESCRIPTION
There is no sample currently for a pattern that lets you share ownership of an account with someone else. This is useful for scenarios where a user has multiple wallets that they want to manage from a single account they own, but still want to maintain their other accounts as valid non-custodial wallets. 

For example, consider a pattern where I make a Blocto account for every platform I login with, but share ownership of each account to one primary to manage them on platforms I trust

NOTE: In order to get this to work, I had to add two new params to the manager resource when it accepts ownership of an account. The manager can now decide whether to rotate auth account capabilities, and whether to revoke keys