### PR TITLE
Add FactoryCapabilityGetter and DelegatorCapabilityGetter to clearify Capabilty fetching mode

### DIFF
--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -761,7 +761,7 @@ pub contract HybridCustody {
             switch view {
                 case Type<MetadataViews.Display>():
                     let childAddress = self.getAddress()
-                    let manager: Capability<&HybridCustody.Manager{HybridCustody.ManagerPublic}> = getAccount(self.parent).getCapability<&HybridCustody.Manager{HybridCustody.ManagerPublic}>(HybridCustody.ManagerPublicPath)
+                    let manager = getAccount(self.parent).getCapability<&HybridCustody.Manager{HybridCustody.ManagerPublic}>(HybridCustody.ManagerPublicPath)
 
                     if !manager.check() {
                         return nil

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -248,12 +248,12 @@ pub contract HybridCustody {
         /// Returns the public interface of FactoryCapabilityGetter
         /// The FactoryCapabilityGetter interface is used to retrieve public capabilities from the `factory`
         /// Note: This is a public method, so it can be called by anyone
-        pub fun getFactoryCapabilityGetterPublic(): &AnyResource{FactoryCapabilityGetterPublic}
+        pub fun borrowFactoryCapabilityGetterPublic(): &AnyResource{FactoryCapabilityGetterPublic}
 
         /// Returns the public interface of DelegatorCapabilityGetter
         /// The DelegatorCapabilityGetter interface is used to retrieve public capabilities from the `delegator`
         /// Note: This is a public method, so it can be called by anyone
-        pub fun getDelegatorCapabilityGetterPublic(): &AnyResource{DelegatorCapabilityGetterPublic}
+        pub fun borrowDelegatorCapabilityGetterPublic(): &AnyResource{DelegatorCapabilityGetterPublic}
 
         pub fun getAddress(): Address
 
@@ -265,11 +265,11 @@ pub contract HybridCustody {
     pub resource interface AccountPrivate {
         /// Returns the private interface of FactoryCapabilityGetter
         /// The FactoryCapabilityGetter interface is used to retrieve private capabilities from the `factory`
-        pub fun getFactoryCapabilityGetter(): &AnyResource{FactoryCapabilityGetterPrivate}
+        pub fun borrowFactoryCapabilityGetter(): &AnyResource{FactoryCapabilityGetterPrivate}
 
         /// Returns the public interface of DelegatorCapabilityGetter
         /// The DelegatorCapabilityGetter interface is used to retrieve public capabilities from the `delegator`
-        pub fun getDelegatorCapabilityGetter(): &AnyResource{DelegatorCapabilityGetterPrivate}
+        pub fun borrowDelegatorCapabilityGetter(): &AnyResource{DelegatorCapabilityGetterPrivate}
 
         /// Returns the capability filter for this account which set by manager, if one exists
         pub fun getManagerCapabilityFilter():  &{CapabilityFilter.Filter}?
@@ -700,25 +700,25 @@ pub contract HybridCustody {
 
         /// Get the public Factory Capability Getter
         ///
-        pub fun getFactoryCapabilityGetterPublic(): &FactoryCapabilityGetter{FactoryCapabilityGetterPublic} {
+        pub fun borrowFactoryCapabilityGetterPublic(): &FactoryCapabilityGetter{FactoryCapabilityGetterPublic} {
             return self.fetchOrCreateFactoryCapabilityGetter()
         }
 
         /// Get the Factory Capability Getter
         ///
-        pub fun getFactoryCapabilityGetter(): &FactoryCapabilityGetter{FactoryCapabilityGetterPrivate} {
+        pub fun borrowFactoryCapabilityGetter(): &FactoryCapabilityGetter{FactoryCapabilityGetterPrivate} {
             return self.fetchOrCreateFactoryCapabilityGetter()
         }
 
         /// Get the public Delegator Capability Getter
         ///
-        pub fun getDelegatorCapabilityGetterPublic(): &DelegatorCapabilityGetter{DelegatorCapabilityGetterPublic} {
+        pub fun borrowDelegatorCapabilityGetterPublic(): &DelegatorCapabilityGetter{DelegatorCapabilityGetterPublic} {
             return self.fetchOrCreateDelegatorCapabilityGetter()
         }
 
         /// Get the Delegator Capability Getter
         ///
-        pub fun getDelegatorCapabilityGetter(): &DelegatorCapabilityGetter{DelegatorCapabilityGetterPrivate} {
+        pub fun borrowDelegatorCapabilityGetter(): &DelegatorCapabilityGetter{DelegatorCapabilityGetterPrivate} {
             return self.fetchOrCreateDelegatorCapabilityGetter()
         }
 

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -226,8 +226,8 @@ pub contract HybridCustody {
     /// General struct interface for the CapabiltyGetter, which is used to retrieve the reference to the
     /// ChildAcountPrivate resource interface
     pub resource interface AccountCapabiltyGetter {
-        pub let manager: Address
-        pub let address: Address
+        access(contract) let manager: Address
+        access(contract) let address: Address
 
         /// The default implementation of this function, will return the ChildAccountPrivate resource interface
         /// Note: This is a private method, so it can only be called by the methods in this file
@@ -564,19 +564,24 @@ pub contract HybridCustody {
     /// Capability getter of Factory mode
     ///
     pub resource FactoryCapabilityGetter: FactoryCapabilityGetterPublic, FactoryCapabilityGetterPrivate, AccountCapabiltyGetter {
-        pub let manager: Address
-        pub let address: Address
+        access(contract) let manager: Address
+        access(contract) let address: Address
 
         init(_ manager: Address, _ address: Address) {
             self.manager = manager
             self.address = address
         }
 
+        /// Returns a public capability for the given path and type for `factory`, if one exists
+        ///
         pub fun getPublicCapability(path: PublicPath, type: Type): Capability? {
             let acctPriv = self.borrowOwnerChildAccount()
             return acctPriv.getPublicCapability(path: path, type: type)
         }
 
+        /// Returns a private capability for the given path and type for `factory`, if one exists
+        /// Note(by Bohao): But I think it won't work in the new CapCons mode.
+        ///
         pub fun getCapability(path: CapabilityPath, type: Type): Capability? {
             let acctPriv = self.borrowOwnerChildAccount()
             return acctPriv.getCapability(path: path, type: type)
@@ -586,19 +591,23 @@ pub contract HybridCustody {
     /// Capability getter of Delegator mode
     ///
     pub resource DelegatorCapabilityGetter: DelegatorCapabilityGetterPublic, DelegatorCapabilityGetterPrivate, AccountCapabiltyGetter {
-        pub let manager: Address
-        pub let address: Address
+        access(contract) let manager: Address
+        access(contract) let address: Address
 
         init(_ manager: Address, _ address: Address) {
             self.manager = manager
             self.address = address
         }
 
+        /// Returns a public capability for the given type for `delegator`, if one exists
+        ///
         pub fun getPublicCapability(type: Type): Capability? {
             let acctPriv = self.borrowOwnerChildAccount()
             return acctPriv.getPublicCapFromDelegator(type: type)
-
         }
+
+        /// Returns a private/public capability for the given type for `delegator`, if one exists
+        ///
         pub fun getCapability(type: Type): Capability? {
             let acctPriv = self.borrowOwnerChildAccount()
             return acctPriv.getPrivateCapFromDelegator(type: type) ?? acctPriv.getPublicCapFromDelegator(type: type)

--- a/scripts/hybrid-custody/get_child_account_nft_capabilities.cdc
+++ b/scripts/hybrid-custody/get_child_account_nft_capabilities.cdc
@@ -1,14 +1,14 @@
 import "HybridCustody"
 import "NonFungibleToken"
 
-// This script iterates through a parent's child accounts, 
+// This script iterates through a parent's child accounts,
 // identifies private paths with an accessible NonFungibleToken.Provider, and returns the corresponding typeIds
 pub fun main(addr: Address):AnyStruct {
   let account = getAuthAccount(addr)
   let manager = getAuthAccount(addr).borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) ?? panic ("manager does not exist")
 
-  var typeIdsWithProvider = {} as {Address: [String]} 
-  
+  var typeIdsWithProvider = {} as {Address: [String]}
+
   let providerType = Type<Capability<&{NonFungibleToken.Provider}>>()
 
   // Iterate through child accounts
@@ -16,14 +16,15 @@ pub fun main(addr: Address):AnyStruct {
     let addr = getAuthAccount(address)
     let foundTypes: [String] = []
     let childAcct = manager.borrowAccount(addr: address) ?? panic("child account not found")
+    let childFactoryGetter = childAcct.borrowFactoryCapabilityGetter()
     // get all private paths
     addr.forEachPrivate(fun (path: PrivatePath, type: Type): Bool {
       // Check which private paths have NFT Provider AND can be borrowed
       if !type.isSubtype(of: providerType){
         return true
       }
-      if let cap = childAcct.getCapability(path: path, type: Type<&{NonFungibleToken.Provider}>()) {
-        let providerCap = cap as! Capability<&{NonFungibleToken.Provider}> 
+      if let cap = childFactoryGetter.getCapability(path: path, type: Type<&{NonFungibleToken.Provider}>()) {
+        let providerCap = cap as! Capability<&{NonFungibleToken.Provider}>
 
         if !providerCap.check(){
           return true

--- a/scripts/hybrid-custody/get_collection_from_inbox.cdc
+++ b/scripts/hybrid-custody/get_collection_from_inbox.cdc
@@ -1,3 +1,4 @@
+import "MetadataViews"
 import "HybridCustody"
 import "NonFungibleToken"
 import "ExampleNFT"
@@ -6,9 +7,27 @@ pub fun main(parent: Address, child: Address) {
     let acct = getAuthAccount(parent)
     let inboxIdentifier = HybridCustody.getChildAccountIdentifier(parent)
 
-    let cap = acct.inbox.claim<&HybridCustody.ChildAccount{HybridCustody.AccountPrivate}>(inboxIdentifier, provider: child)
-        ?? panic("no inbox entry found")
+    let cap = acct.inbox.claim<&HybridCustody.ChildAccount{HybridCustody.AccountPrivate, HybridCustody.AccountPublic, MetadataViews.Resolver}>(inboxIdentifier, provider: child)
+            ?? panic("no inbox entry found")
 
-    cap.borrow()!.getCapability(path: ExampleNFT.CollectionPublicPath, type: Type<&{NonFungibleToken.CollectionPublic}>())
+    // Note(by Bohao): Under the current implementation, cap must be added to the manager before collection can be obtained normally.
+    //                 In a sense, I think this is more reasonable.
+    if acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) == nil {
+        let m <- HybridCustody.createManager(filter: nil)
+        acct.save(<- m, to: HybridCustody.ManagerStoragePath)
+
+        acct.unlink(HybridCustody.ManagerPublicPath)
+        acct.unlink(HybridCustody.ManagerPrivatePath)
+
+        acct.link<&HybridCustody.Manager{HybridCustody.ManagerPrivate, HybridCustody.ManagerPublic}>(HybridCustody.ManagerPrivatePath, target: HybridCustody.ManagerStoragePath)
+        acct.link<&HybridCustody.Manager{HybridCustody.ManagerPublic}>(HybridCustody.ManagerPublicPath, target: HybridCustody.ManagerStoragePath)
+    }
+
+    let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+        ?? panic("manager no found")
+    manager.addAccount(cap: cap)
+
+    let factoryGetter = cap.borrow()!.borrowFactoryCapabilityGetter()
+    factoryGetter.getCapability(path: ExampleNFT.CollectionPublicPath, type: Type<&{NonFungibleToken.CollectionPublic}>())
         ?? panic("capability not found")
 }

--- a/scripts/hybrid-custody/get_examplenft_collection_from_delegator.cdc
+++ b/scripts/hybrid-custody/get_examplenft_collection_from_delegator.cdc
@@ -9,8 +9,10 @@ pub fun main(parent: Address, child: Address, isPublic: Bool) {
 
     let t = Type<Capability<&ExampleNFT.Collection>>()
 
-    let cap = (isPublic ? acct.getPublicCapFromDelegator(type: t) : acct.getPrivateCapFromDelegator(type: t))
+    let delegatorGetter = acct.borrowDelegatorCapabilityGetter()
+    // Note(by Bohao): Actually, there is no need to use `ispublic`. You can directly use `delegatorGetter.getCapability`.
+    let cap = (isPublic ? delegatorGetter.getPublicCapability(type: t) : delegatorGetter.getCapability(type: t))
         ?? panic("capability not found")
-    
+
     assert(cap.getType() == t, message: "mismatched capability types")
 }

--- a/scripts/hybrid-custody/get_ft_provider_capability.cdc
+++ b/scripts/hybrid-custody/get_ft_provider_capability.cdc
@@ -10,7 +10,8 @@ pub fun main(parent: Address, child: Address) {
         ?? panic("manager does not exist")
 
     let childAcct = m.borrowAccount(addr: child) ?? panic("child account not found")
-    let nakedCap = childAcct.getCapability(path: /private/exampleTokenProvider, type: Type<&{FungibleToken.Provider}>())
+    let factoryGetter = childAcct.borrowFactoryCapabilityGetter()
+    let nakedCap = factoryGetter.getCapability(path: /private/exampleTokenProvider, type: Type<&{FungibleToken.Provider}>())
 				?? panic("Could not borrow reference to the owner's Vault!")
     let providerCap = nakedCap as! Capability<&{FungibleToken.Provider}>
     assert(providerCap.check(), message: "invalid provider capability")

--- a/scripts/hybrid-custody/get_nft_collection_public_capability.cdc
+++ b/scripts/hybrid-custody/get_nft_collection_public_capability.cdc
@@ -14,7 +14,8 @@ pub fun main(parent: Address, child: Address) {
 
     let d = ExampleNFT.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
 
-    let nakedCap = childAcct.getCapability(path: d.providerPath, type: Type<&{NonFungibleToken.CollectionPublic}>())
+    let factoryGetter = childAcct.borrowFactoryCapabilityGetter()
+    let nakedCap = factoryGetter.getCapability(path: d.providerPath, type: Type<&{NonFungibleToken.CollectionPublic}>())
         ?? panic("capability not found")
 
     let cap = nakedCap as! Capability<&{NonFungibleToken.CollectionPublic}>

--- a/scripts/hybrid-custody/get_nft_provider_capability.cdc
+++ b/scripts/hybrid-custody/get_nft_provider_capability.cdc
@@ -14,7 +14,8 @@ pub fun main(parent: Address, child: Address) {
 
     let d = ExampleNFT.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
 
-    let nakedCap = childAcct.getCapability(path: d.providerPath, type: Type<&{NonFungibleToken.Provider}>())
+    let factoryGetter = childAcct.borrowFactoryCapabilityGetter()
+    let nakedCap = factoryGetter.getCapability(path: d.providerPath, type: Type<&{NonFungibleToken.Provider}>())
         ?? panic("capability not found")
 
     let cap = nakedCap as! Capability<&{NonFungibleToken.Provider}>

--- a/scripts/test/test_get_accessible_child_nfts.cdc
+++ b/scripts/test/test_get_accessible_child_nfts.cdc
@@ -2,7 +2,7 @@ import "HybridCustody"
 import "NonFungibleToken"
 import "MetadataViews"
 
-/* 
+/*
  * TEST SCRIPT
  * This script is a replication of that found in hybrid-custody/get_accessible_child_account_nfts.cdc as it's the best as
  * as can be done without accessing the script's return type in the Cadence testing framework
@@ -25,8 +25,8 @@ pub fun assertPassing(result: {Address: {UInt64: MetadataViews.Display}}, expect
 pub fun main(addr: Address, expectedAddressToIDs: {Address: [UInt64]}){
   let manager = getAuthAccount(addr).borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) ?? panic ("manager does not exist")
 
-  var typeIdsWithProvider = {} as {Address: [String]} 
-  var nftViews = {} as {Address: {UInt64: MetadataViews.Display}} 
+  var typeIdsWithProvider = {} as {Address: [String]}
+  var nftViews = {} as {Address: {UInt64: MetadataViews.Display}}
 
   let providerType = Type<Capability<&{NonFungibleToken.Provider}>>()
   let collectionType: Type = Type<@{NonFungibleToken.CollectionPublic}>()
@@ -36,6 +36,7 @@ pub fun main(addr: Address, expectedAddressToIDs: {Address: [UInt64]}){
     let foundTypes: [String] = []
     let views: {UInt64: MetadataViews.Display} = {}
     let childAcct = manager.borrowAccount(addr: address) ?? panic("child account not found")
+    let factoryGetter = childAcct.borrowFactoryCapabilityGetter()
     // get all private paths
     acct.forEachPrivate(fun (path: PrivatePath, type: Type): Bool {
       // Check which private paths have NFT Provider AND can be borrowed
@@ -43,8 +44,8 @@ pub fun main(addr: Address, expectedAddressToIDs: {Address: [UInt64]}){
         return true
       }
 
-      if let cap: Capability = childAcct.getCapability(path: path, type: Type<&{NonFungibleToken.Provider}>()) {
-        let providerCap = cap as! Capability<&{NonFungibleToken.Provider}> 
+      if let cap: Capability = factoryGetter.getCapability(path: path, type: Type<&{NonFungibleToken.Provider}>()) {
+        let providerCap = cap as! Capability<&{NonFungibleToken.Provider}>
 
         if !providerCap.check(){
           return true
@@ -73,7 +74,7 @@ pub fun main(addr: Address, expectedAddressToIDs: {Address: [UInt64]}){
             if type.isInstance(collectionType) {
               continue
             }
-            if let collection = acct.borrow<&{NonFungibleToken.CollectionPublic}>(from: path) { 
+            if let collection = acct.borrow<&{NonFungibleToken.CollectionPublic}>(from: path) {
               // Iterate over IDs & resolve the view
               for id in collection.getIDs() {
                 let nft = collection.borrowNFT(id: id)

--- a/transactions/hybrid-custody/send_child_ft_with_parent.cdc
+++ b/transactions/hybrid-custody/send_child_ft_with_parent.cdc
@@ -14,12 +14,13 @@ transaction(amount: UFix64, to: Address, child: Address) {
         let m = signer.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager does not exist")
         let childAcct = m.borrowAccount(addr: child) ?? panic("child account not found")
-        
+
         //get Ft cap from child account
-        let cap = childAcct.getCapability(path: /private/exampleTokenProvider, type: Type<&{FungibleToken.Provider}>()) ?? panic("no cap found")
+        let factoryGetter = childAcct.borrowFactoryCapabilityGetter()
+        let cap = factoryGetter.getCapability(path: /private/exampleTokenProvider, type: Type<&{FungibleToken.Provider}>()) ?? panic("no cap found")
         let providerCap = cap as! Capability<&{FungibleToken.Provider}>
         assert(providerCap.check(), message: "invalid provider capability")
-        
+
         // Get a reference to the child's stored vault
         let vaultRef = providerCap.borrow()!
 
@@ -41,4 +42,3 @@ transaction(amount: UFix64, to: Address, child: Address) {
         receiverRef.deposit(from: <-self.paymentVault)
     }
 }
- 


### PR DESCRIPTION
The original intention of the modification is to separate the usage experience of `Factory` and `Delegator` from a development perspective by minimizing modifications to the interface.

PS. Some modifications are automatically done by my VSCode.