### PR TITLE
Add badges in `README` for integration tests and code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hybrid Custody
 
+![Tests](https://github.com/onflow/hybrid-custody/actions/workflows/integration-tests.yml/badge.svg) [![codecov](https://codecov.io/gh/onflow/hybrid-custody/branch/main/graph/badge.svg?token=5GWD5NHEKF)](https://codecov.io/gh/onflow/hybrid-custody)
+
 **NOTE: This contract is still under development, its address is likely to be redeployed to testnet once it is finished**
 
 **Please see [Flow's documentation about account linking](https://developers.flow.com/concepts/hybrid-custody/guides/linking-accounts) for more information and examples.**


### PR DESCRIPTION
This will add two badges in the `README`, as shown below:

![Screenshot from 2023-08-16 13-02-31](https://github.com/onflow/hybrid-custody/assets/1778965/bc73a3ec-c478-4361-ba00-7f2bc25ec238)
