### PR TITLE
Extend AccountPublic to allow retrieval of Factory and Filter capabilities

### DIFF
--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -198,8 +198,8 @@ pub contract HybridCustody {
         pub fun getPublicCapability(path: PublicPath, type: Type): Capability?
         pub fun getPublicCapFromDelegator(type: Type): Capability?
         pub fun getAddress(): Address
-        pub fun getCapabilityFactory(): Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>
-        pub fun getCapabilityFilter(): Capability<&{CapabilityFilter.Filter}>
+        pub fun getCapabilityFactoryManager(): &{CapabilityFactory.Getter}?
+        pub fun getCapabilityFilter(): &{CapabilityFilter.Filter}?
     }
 
     /// Methods accessible to the designated parent of a ChildAccount
@@ -720,14 +720,14 @@ pub contract HybridCustody {
 
         /// Returns a capability to this child account's CapabilityFilter
         ///
-        pub fun getCapabilityFilter(): Capability<&{CapabilityFilter.Filter}> {
-            return self.filter
+        pub fun getCapabilityFilter(): &{CapabilityFilter.Filter}? {
+            return self.filter.check() ? self.filter.borrow() : nil
         }
 
         /// Returns a capability to this child account's CapabilityFactory
         ///
-        pub fun getCapabilityFactory(): Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}> {
-            return self.factory
+        pub fun getCapabilityFactoryManager(): &{CapabilityFactory.Getter}? {
+            return self.factory.check() ? self.factory.borrow() : nil
         }
 
         destroy () {

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -198,6 +198,8 @@ pub contract HybridCustody {
         pub fun getPublicCapability(path: PublicPath, type: Type): Capability?
         pub fun getPublicCapFromDelegator(type: Type): Capability?
         pub fun getAddress(): Address
+        pub fun getCapabilityFactory(): Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>
+        pub fun getCapabilityFilter(): Capability<&{CapabilityFilter.Filter}>
     }
 
     /// Methods accessible to the designated parent of a ChildAccount
@@ -714,6 +716,18 @@ pub contract HybridCustody {
 
             self.data = {}
             self.resources <- {}
+        }
+
+        /// Returns a capability to this child account's CapabilityFilter
+        ///
+        pub fun getCapabilityFilter(): Capability<&{CapabilityFilter.Filter}> {
+            return self.filter
+        }
+
+        /// Returns a capability to this child account's CapabilityFactory
+        ///
+        pub fun getCapabilityFactory(): Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}> {
+            return self.factory
         }
 
         destroy () {

--- a/scripts/test/can_get_child_factory_and_filter_caps.cdc
+++ b/scripts/test/can_get_child_factory_and_filter_caps.cdc
@@ -1,0 +1,19 @@
+import "HybridCustody"
+
+// @addr - The address of the child account
+// @parent - The parent account that this child is assigned to
+pub fun main(addr: Address, parent: Address): Bool {
+    let identifier = HybridCustody.getChildAccountIdentifier(parent)
+    let path = PrivatePath(identifier: identifier) ?? panic("invalid public path identifier for parent address")
+
+    let acctPublic = getAuthAccount(addr).getCapability<&HybridCustody.ChildAccount{HybridCustody.AccountPublic}>(path)
+        .borrow() ?? panic("account public not found")
+    
+    let filter = acctPublic.getCapabilityFactory()
+    assert(filter.check(), message: "capability filter is not valid")
+
+    let factory = acctPublic.getCapabilityFactory()
+    assert(factory.check(), message: "capability factory is not valid")
+
+    return true
+}

--- a/scripts/test/can_get_child_factory_and_filter_caps.cdc
+++ b/scripts/test/can_get_child_factory_and_filter_caps.cdc
@@ -9,11 +9,11 @@ pub fun main(addr: Address, parent: Address): Bool {
     let acctPublic = getAuthAccount(addr).getCapability<&HybridCustody.ChildAccount{HybridCustody.AccountPublic}>(path)
         .borrow() ?? panic("account public not found")
     
-    let filter = acctPublic.getCapabilityFactory()
-    assert(filter.check(), message: "capability filter is not valid")
+    let factory = acctPublic.getCapabilityFactoryManager()
+    assert(factory != nil, message: "capability factory is not valid")
 
-    let factory = acctPublic.getCapabilityFilter()
-    assert(factory.check(), message: "capability factory is not valid")
+    let filter = acctPublic.getCapabilityFilter()
+    assert(filter != nil, message: "capability filter is not valid")
 
     return true
 }

--- a/scripts/test/can_get_child_factory_and_filter_caps.cdc
+++ b/scripts/test/can_get_child_factory_and_filter_caps.cdc
@@ -12,7 +12,7 @@ pub fun main(addr: Address, parent: Address): Bool {
     let filter = acctPublic.getCapabilityFactory()
     assert(filter.check(), message: "capability filter is not valid")
 
-    let factory = acctPublic.getCapabilityFactory()
+    let factory = acctPublic.getCapabilityFilter()
     assert(factory.check(), message: "capability factory is not valid")
 
     return true

--- a/test/HybridCustody_tests.cdc
+++ b/test/HybridCustody_tests.cdc
@@ -797,6 +797,14 @@ pub fun testRemoveParent() {
     txExecutor("hybrid-custody/remove_parent_from_child.cdc", [child], [parent.address], nil, nil)
 }
 
+pub fun testGetChildAccountCapabilityFilterAndFactory() {
+    let child = blockchain.createAccount()
+    let parent = blockchain.createAccount()
+
+    setupChildAndParent_FilterKindAll(child: child, parent: parent)
+    scriptExecutor("test/can_get_child_factory_and_filter_caps.cdc", [child.address, parent.address])
+}
+
 // --------------- End Test Cases ---------------
 
 


### PR DESCRIPTION

Without this, it's very difficult to detect whether a certain capability is allowed to be retrieved unless you run scripts manually. With helper methods like this (I'm sure others will be needed), you can borrow and return details of the filter/factory yourself and then process them offline