### PR TITLE
Fix: rotateAuthAccount failed when called twice

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         go-version: 1.18
     - name: Install Flow CLI
-      run: bash -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)" -- v1.3.4
+      run: bash -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)" -- v1.4.4
     - name: Run tests
       run: sh ./test.sh
     - name: Normalize coverage report filepaths

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -1023,7 +1023,7 @@ pub contract HybridCustody {
             // NOTE: This path cannot be sufficiently randomly generated, an app calling this function could build a
             // capability to this path before it is made, thus maintaining ownership despite making it look like they
             // gave it away. Until capability controllers, this method should not be fully trusted.
-            let authAcctPath = "HybridCustodyRelinquished"
+            let authAcctPath = "HybridCustodyRelinquished_"
                 .concat(HybridCustody.account.address.toString())
                 .concat(getCurrentBlock().height.toString())
                 .concat((pathsToUnlink.length + 1).toString()) // ensure that the path is different from the previous one

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -1040,7 +1040,7 @@ pub contract HybridCustody {
             let authAcctPath = "HybridCustodyRelinquished_"
                 .concat(HybridCustody.account.address.toString())
                 .concat(getCurrentBlock().height.toString())
-                .concat((pathsToUnlink.length + 1).toString()) // ensure that the path is different from the previous one
+                .concat(unsafeRandom().toString()) // ensure that the path is different from the previous one
             let acctCap = acct.linkAccount(PrivatePath(identifier: authAcctPath)!)!
 
             self.acct = acctCap

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -1023,7 +1023,10 @@ pub contract HybridCustody {
             // NOTE: This path cannot be sufficiently randomly generated, an app calling this function could build a
             // capability to this path before it is made, thus maintaining ownership despite making it look like they
             // gave it away. Until capability controllers, this method should not be fully trusted.
-            let authAcctPath = "HybridCustodyRelinquished".concat(HybridCustody.account.address.toString()).concat(getCurrentBlock().height.toString())
+            let authAcctPath = "HybridCustodyRelinquished"
+                .concat(HybridCustody.account.address.toString())
+                .concat(getCurrentBlock().height.toString())
+                .concat((pathsToUnlink.length + 1).toString()) // ensure that the path is different from the previous one
             let acctCap = acct.linkAccount(PrivatePath(identifier: authAcctPath)!)!
 
             self.acct = acctCap


### PR DESCRIPTION
When `giveOwnership` and `addOwnedAccount` are executed in the same transaction
`rotateAuthAccount` will be called twice.
However, during the second call, since authAcctPath is the same, it will cause `acct.linkAccount` to return `nil` as a result.

Personal opinion, it would be better to change `HybridCustody` overall to CapCons coding style.