### PR TITLE
Add Deployment & Hosted Filter/Factory Details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage.lcov
 .idea
 *.pkey
 *.private
+*.pem

--- a/README.md
+++ b/README.md
@@ -1,27 +1,47 @@
 # Hybrid Custody
 
-![Tests](https://github.com/onflow/hybrid-custody/actions/workflows/integration-tests.yml/badge.svg) [![codecov](https://codecov.io/gh/onflow/hybrid-custody/branch/main/graph/badge.svg?token=5GWD5NHEKF)](https://codecov.io/gh/onflow/hybrid-custody)
+![Tests](https://github.com/onflow/hybrid-custody/actions/workflows/integration-tests.yml/badge.svg)
+[![codecov](https://codecov.io/gh/onflow/hybrid-custody/branch/main/graph/badge.svg?token=5GWD5NHEKF)](https://codecov.io/gh/onflow/hybrid-custody)
 
-**NOTE: This contract is still under development, its address is likely to be redeployed to testnet once it is finished**
+**NOTE: This contract is still under development, its address is likely to be redeployed to testnet once it is
+finished**
 
-**Please see [Flow's documentation about account linking](https://developers.flow.com/concepts/hybrid-custody/guides/linking-accounts) for more information and examples.**
+**Please see [Flow's documentation about account
+linking](https://developers.flow.com/concepts/hybrid-custody/guides/linking-accounts) for more information and
+examples.**
 
-This repo contains a primary contract for managing ChildAccounts to permit
-hybrid custody in scenarios where apps only want to share a subset of resources on their
-accounts with various parents. In many cases, this will be a user's primary wallet outside of the
-application a child account came from
+This repo contains a primary contract for managing ChildAccounts to permit hybrid custody in scenarios where apps only
+want to share a subset of resources on their accounts with various parents. In many cases, this will be a user's primary
+wallet outside of the application a child account came from
 
-Apps need assurances that their own resources are safe from malicious actors, so giving out full
-custody might not be the form of hybrid custody that they want. In this model, the app still
-maintains control of their managed accounts, but they can:
+Apps need assurances that their own resources are safe from malicious actors, so giving out full custody might not be
+the form of hybrid custody that they want. In this model, the app still maintains control of their managed accounts, but
+they can:
 
-1. Share capabilities freely, with a few built-in controls over the types of capabilities that can be returned with some helper contracts (the `CapabilityFactory`, and `CapabilityFilter`)
+1. Share capabilities freely, with a few built-in controls over the types of capabilities that can be returned with some
+   helper contracts (the `CapabilityFactory`, and `CapabilityFilter`)
 1. Share additional capabilities (public or private) with a parent account via a `CapabilityDelegator` resource
+
+## Deployment Details
 
 | Network | Address                                                                              |
 | ------- | ------------------------------------------------------------------------------------ |
 | Testnet | [0x294e44e1ec6993c6](https://testnet.contractbrowser.com/account/0x294e44e1ec6993c6) |
 | Mainnet | [0xd8a7e05a7ac670c0](https://contractbrowser.com/account/0xd8a7e05a7ac670c0) |
+
+### Hosted `CapabilityFactory` & `CapabilityFilter` Implementations
+
+> :information_source: `CapabilityFactory.Manager` implementations and `CapabilityFilter.AllowAllFilter` have been
+> deployed to the accounts below for generalized use cases to make account linking as easy as possible. These
+> generalized implementations likely cover most use cases, but you'll want to weigh the decision to use them according
+> to your risk tolerance and specific scenario.
+
+| Use Case | Testnet Address                                                                       | Mainnet Address                         |
+| -------- | ------------------------------------------------------------------------------------- | ------- |
+| NFT Capability Factories       | [0x40439a07e712b713](https://f.dnz.dev/0x40439a07e712b713/storage/CapabilityFactory_0x294e44e1ec6993c6) | [0xee9ff4f07a2d6dad](https://f.dnz.dev/0xee9ff4f07a2d6dad/storage/CapabilityFactory_0xd8a7e05a7ac670c0) |
+| FT Capability Factories        | [0x5617ff347e16bd72](https://f.dnz.dev/0x5617ff347e16bd72/storage/CapabilityFactory_0x294e44e1ec6993c6) | [0x410aa603925923d9](https://f.dnz.dev/0x410aa603925923d9/storage/CapabilityFactory_0xd8a7e05a7ac670c0) |
+| NFT + FT Capability Factories  | [0x4b69a89e2b97c93a](https://f.dnz.dev/0x4b69a89e2b97c93a/storage/CapabilityFactory_0x294e44e1ec6993c6) | [0x071d382668250606](https://f.dnz.dev/0x071d382668250606/storage/CapabilityFactory_0xd8a7e05a7ac670c0) |
+| AllowAllFilter                 | [0x30c672282cfa3adf](https://f.dnz.dev/0x30c672282cfa3adf/storage/CapabilityFilter_0x294e44e1ec6993c6) | [0x78e93a79b05d0d7d](https://f.dnz.dev/0x78e93a79b05d0d7d/storage/CapabilityFilter_0xd8a7e05a7ac670c0)  |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ they can:
 > to your risk tolerance and specific scenario.
 
 | Use Case | Testnet Address                                                                       | Mainnet Address                         |
-| -------- | ------------------------------------------------------------------------------------- | ------- |
-| NFT Capability Factories       | [0x40439a07e712b713](https://f.dnz.dev/0x40439a07e712b713/storage/CapabilityFactory_0x294e44e1ec6993c6) | [0xee9ff4f07a2d6dad](https://f.dnz.dev/0xee9ff4f07a2d6dad/storage/CapabilityFactory_0xd8a7e05a7ac670c0) |
-| FT Capability Factories        | [0x5617ff347e16bd72](https://f.dnz.dev/0x5617ff347e16bd72/storage/CapabilityFactory_0x294e44e1ec6993c6) | [0x410aa603925923d9](https://f.dnz.dev/0x410aa603925923d9/storage/CapabilityFactory_0xd8a7e05a7ac670c0) |
-| NFT + FT Capability Factories  | [0x4b69a89e2b97c93a](https://f.dnz.dev/0x4b69a89e2b97c93a/storage/CapabilityFactory_0x294e44e1ec6993c6) | [0x071d382668250606](https://f.dnz.dev/0x071d382668250606/storage/CapabilityFactory_0xd8a7e05a7ac670c0) |
-| AllowAllFilter                 | [0x30c672282cfa3adf](https://f.dnz.dev/0x30c672282cfa3adf/storage/CapabilityFilter_0x294e44e1ec6993c6) | [0x78e93a79b05d0d7d](https://f.dnz.dev/0x78e93a79b05d0d7d/storage/CapabilityFilter_0xd8a7e05a7ac670c0)  |
+| -------- | ------------------------------------------------------------------------------------- | --------------------------------------- |
+| NFT Capability Factories       | [0x1055970ee34ef4dc](https://f.dnz.dev/0x1055970ee34ef4dc/storage/CapabilityFactory_0x294e44e1ec6993c6) | [0xee9ff4f07a2d6dad](https://f.dnz.dev/0xee9ff4f07a2d6dad/storage/CapabilityFactory_0xd8a7e05a7ac670c0) |
+| FT Capability Factories        | [0x08bed9e8508ed20e](https://f.dnz.dev/0x08bed9e8508ed20e/storage/CapabilityFactory_0x294e44e1ec6993c6) | [0x410aa603925923d9](https://f.dnz.dev/0x410aa603925923d9/storage/CapabilityFactory_0xd8a7e05a7ac670c0) |
+| NFT + FT Capability Factories  | [0x1b7fa5972fcb8af5](https://f.dnz.dev/0x1b7fa5972fcb8af5/storage/CapabilityFactory_0x294e44e1ec6993c6) | [0x071d382668250606](https://f.dnz.dev/0x071d382668250606/storage/CapabilityFactory_0xd8a7e05a7ac670c0) |
+| AllowAllFilter                 | [0xe2664be06bb0fe62](https://f.dnz.dev/0xe2664be06bb0fe62/storage/CapabilityFilter_0x294e44e1ec6993c6) | [0x78e93a79b05d0d7d](https://f.dnz.dev/0x78e93a79b05d0d7d/storage/CapabilityFilter_0xd8a7e05a7ac670c0)  |
 
 ## Development
 

--- a/flow.json
+++ b/flow.json
@@ -1,25 +1,19 @@
 {
-	"emulators": {
-		"default": {
-			"port": 3569,
-			"serviceAccount": "emulator-account"
-		}
-	},
 	"contracts": {
 		"AddressUtils": {
 			"source": "./modules/flow-utils/cadence/contracts/AddressUtils.cdc",
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
-				"mainnet": "a340dc0a4ec828ab",
-				"testnet": "31ad40c07a2a9788"
+				"testnet": "31ad40c07a2a9788",
+				"mainnet": "a340dc0a4ec828ab"
 			}
 		},
 		"ArrayUtils": {
 			"source": "./modules/flow-utils/cadence/contracts/ArrayUtils.cdc",
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
-				"mainnet": "a340dc0a4ec828ab",
-				"testnet": "31ad40c07a2a9788"
+				"testnet": "31ad40c07a2a9788",
+				"mainnet": "a340dc0a4ec828ab"
 			}
 		},
 		"CapabilityDelegator": {
@@ -93,16 +87,16 @@
 			"source": "",
 			"aliases": {
 				"emulator": "0ae53cb6e3f42a79",
-				"mainnet": "1654653399040a61",
-				"testnet": "7e60df042a9c0868"
+				"testnet": "7e60df042a9c0868",
+				"mainnet": "1654653399040a61"
 			}
 		},
 		"FungibleToken": {
 			"source": "./modules/flow-nft/contracts/utility/FungibleToken.cdc",
 			"aliases": {
 				"emulator": "ee82856bf20e2aa6",
-				"mainnet": "f233dcee88fe0abe",
-				"testnet": "9a0766d93b6608b7"
+				"testnet": "9a0766d93b6608b7",
+				"mainnet": "f233dcee88fe0abe"
 			}
 		},
 		"HybridCustody": {
@@ -117,8 +111,8 @@
 			"source": "./modules/flow-nft/contracts/MetadataViews.cdc",
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
-				"mainnet": "1d7e57aa55817448",
-				"testnet": "631e88ae7f1d7c20"
+				"testnet": "631e88ae7f1d7c20",
+				"mainnet": "1d7e57aa55817448"
 			}
 		},
 		"NFTCollectionPublicFactory": {
@@ -148,24 +142,24 @@
 			"source": "./modules/flow-nft/contracts/NonFungibleToken.cdc",
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
-				"mainnet": "1d7e57aa55817448",
-				"testnet": "631e88ae7f1d7c20"
+				"testnet": "631e88ae7f1d7c20",
+				"mainnet": "1d7e57aa55817448"
 			}
 		},
 		"StringUtils": {
 			"source": "./modules/flow-utils/cadence/contracts/StringUtils.cdc",
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
-				"mainnet": "a340dc0a4ec828ab",
-				"testnet": "31ad40c07a2a9788"
+				"testnet": "31ad40c07a2a9788",
+				"mainnet": "a340dc0a4ec828ab"
 			}
 		},
 		"ViewResolver": {
 			"source": "./modules/flow-nft/contracts/ViewResolver.cdc",
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
-				"mainnet": "1d7e57aa55817448",
-				"testnet": "631e88ae7f1d7c20"
+				"testnet": "631e88ae7f1d7c20",
+				"mainnet": "1d7e57aa55817448"
 			}
 		}
 	},
@@ -176,6 +170,14 @@
 		"testnet": "access.devnet.nodes.onflow.org:9000"
 	},
 	"accounts": {
+		"allow-all-mainnet": {
+			"address": "78e93a79b05d0d7d",
+			"key": {
+				"type": "google-kms",
+				"hashAlgorithm": "SHA2_256",
+				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-mainnet/cryptoKeys/hybrid-custody-mainnet-key/cryptoKeyVersions/1"
+			}
+		},
 		"emulator-account": {
 			"address": "f8d6e0586b0a20c7",
 			"key": "686779d775e5fcbf8d2f4a85cb4c53525d02b7ef53230d180fc16f35d9b7d025"
@@ -192,8 +194,16 @@
 				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-mainnet/cryptoKeys/hybrid-custody-mainnet-key/cryptoKeyVersions/1"
 			}
 		},
-		"nft-manager-mainnet": {
-			"address": "ee9ff4f07a2d6dad",
+		"hc-testnet": {
+			"address": "294e44e1ec6993c6",
+			"key": {
+				"type": "google-kms",
+				"hashAlgorithm": "SHA2_256",
+				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-testnet/cryptoKeys/hybrid-custody-testnet-key/cryptoKeyVersions/1"
+			}
+		},
+		"ft-manager-mainnet": {
+			"address": "410aa603925923d9",
 			"key": {
 				"type": "google-kms",
 				"hashAlgorithm": "SHA2_256",
@@ -208,20 +218,12 @@
 				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-mainnet/cryptoKeys/hybrid-custody-mainnet-key/cryptoKeyVersions/1"
 			}
 		},
-		"allow-all-mainnet": {
-			"address": "78e93a79b05d0d7d",
+		"nft-manager-mainnet": {
+			"address": "ee9ff4f07a2d6dad",
 			"key": {
 				"type": "google-kms",
 				"hashAlgorithm": "SHA2_256",
 				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-mainnet/cryptoKeys/hybrid-custody-mainnet-key/cryptoKeyVersions/1"
-			}
-		},
-		"hc-testnet": {
-			"address": "294e44e1ec6993c6",
-			"key": {
-				"type": "google-kms",
-				"hashAlgorithm": "SHA2_256",
-				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-testnet/cryptoKeys/hybrid-custody-testnet-key/cryptoKeyVersions/1"
 			}
 		}
 	},

--- a/flow.json
+++ b/flow.json
@@ -178,6 +178,14 @@
 				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-mainnet/cryptoKeys/hybrid-custody-mainnet-key/cryptoKeyVersions/1"
 			}
 		},
+		"allow-all-testnet": {
+			"address": "0xe2664be06bb0fe62",
+			"key": {
+				"type": "google-kms",
+				"hashAlgorithm": "SHA2_256",
+				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-testnet/cryptoKeys/hybrid-custody-testnet-key/cryptoKeyVersions/1"
+			}
+		},
 		"emulator-account": {
 			"address": "f8d6e0586b0a20c7",
 			"key": "686779d775e5fcbf8d2f4a85cb4c53525d02b7ef53230d180fc16f35d9b7d025"
@@ -210,6 +218,14 @@
 				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-mainnet/cryptoKeys/hybrid-custody-mainnet-key/cryptoKeyVersions/1"
 			}
 		},
+		"ft-manager-testnet": {
+			"address": "0x08bed9e8508ed20e",
+			"key": {
+				"type": "google-kms",
+				"hashAlgorithm": "SHA2_256",
+				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-testnet/cryptoKeys/hybrid-custody-testnet-key/cryptoKeyVersions/1"
+			}
+		},
 		"nft-ft-manager-mainnet": {
 			"address": "071d382668250606",
 			"key": {
@@ -218,12 +234,28 @@
 				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-mainnet/cryptoKeys/hybrid-custody-mainnet-key/cryptoKeyVersions/1"
 			}
 		},
+		"nft-ft-manager-testnet": {
+			"address": "0x1b7fa5972fcb8af5",
+			"key": {
+				"type": "google-kms",
+				"hashAlgorithm": "SHA2_256",
+				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-testnet/cryptoKeys/hybrid-custody-testnet-key/cryptoKeyVersions/1"
+			}
+		},
 		"nft-manager-mainnet": {
 			"address": "ee9ff4f07a2d6dad",
 			"key": {
 				"type": "google-kms",
 				"hashAlgorithm": "SHA2_256",
 				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-mainnet/cryptoKeys/hybrid-custody-mainnet-key/cryptoKeyVersions/1"
+			}
+		},
+		"nft-manager-testnet": {
+			"address": "0x1055970ee34ef4dc",
+			"key": {
+				"type": "google-kms",
+				"hashAlgorithm": "SHA2_256",
+				"resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-testnet/cryptoKeys/hybrid-custody-testnet-key/cryptoKeyVersions/1"
 			}
 		}
 	},


### PR DESCRIPTION
Related: #155

Adds hosted Factory/Filter details to README as well as Filter details to flow config. This is after configuring NFT, FT, & NFT+FT related Factory Managers as well as AllowAllFilter at the listed addresses on Testnet.