### PR TITLE
Crescendo

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,11 +20,9 @@ jobs:
       with:
         go-version: 1.18
     - name: Install Flow CLI
-      run: bash -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)" -- v1.5.0
+      run: bash -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/feature/stable-cadence/install.sh)"
     - name: Run tests
       run: sh ./test.sh
-    - name: Normalize coverage report filepaths
-      run : sh ./normalize_coverage_report.sh
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage.lcov
 *.pkey
 *.private
 *.pem
+node_modules/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "modules/flow-nft"]
 	path = modules/flow-nft
-	url = https://github.com/Flowtyio/flow-nft.git
-[submodule "flow-ft"]
-	path = flow-ft
-	url = https://github.com/Flowtyio/flow-ft.git
+	url = https://github.com/onflow/flow-nft.git
 [submodule "modules/flow-utils"]
 	path = modules/flow-utils
-	url = https://github.com/Flowtyio/flow-utils.git
+	url = https://github.com/green-goo-dao/flow-utils.git
+[submodule "modules/flow-ft"]
+	path = modules/flow-ft
+	url = https://github.com/onflow/flow-ft.git

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,8 @@ ignore:
   - "contracts/standard/ExampleNFT.cdc"
   - "contracts/standard/ExampleNFT2.cdc"
   - "contracts/standard/ExampleToken.cdc"
+  - "contracts/factories/FTBalanceFactory.cdc"
+  - "contracts/factories/FTProviderFactory.cdc"
+  - "contracts/factories/FTReceiverFactory.cdc"
+  - "contracts/factories/NFTCollectionPublicFactory.cdc"
+  - "contracts/factories/NFTProviderFactory.cdc"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "contracts/standard/ExampleNFT.cdc"
+  - "contracts/standard/ExampleNFT2.cdc"
+  - "contracts/standard/ExampleToken.cdc"

--- a/contracts/CapabilityDelegator.cdc
+++ b/contracts/CapabilityDelegator.cdc
@@ -7,48 +7,48 @@
 /// private `Delegator` can only be borrowed from the child account when you have access to the full `ChildAccount` 
 /// resource.
 ///
-pub contract CapabilityDelegator {
+access(all) contract CapabilityDelegator {
 
     /* --- Canonical Paths --- */
     //
-    pub let StoragePath: StoragePath
-    pub let PrivatePath: PrivatePath
-    pub let PublicPath: PublicPath
+    access(all) let StoragePath: StoragePath
+    access(all) let PrivatePath: PrivatePath
+    access(all) let PublicPath: PublicPath
     
     /* --- Events --- */
     //
-    pub event DelegatorCreated(id: UInt64)
-    pub event DelegatorUpdated(id: UInt64, capabilityType: Type, isPublic: Bool, active: Bool)
+    access(all) event DelegatorCreated(id: UInt64)
+    access(all) event DelegatorUpdated(id: UInt64, capabilityType: Type, isPublic: Bool, active: Bool)
 
     /// Private interface for Capability retrieval
     ///
-    pub resource interface GetterPrivate {
-        pub fun getPrivateCapability(_ type: Type): Capability? {
+    access(all) resource interface GetterPrivate {
+        access(Capabilities) view fun getPrivateCapability(_ type: Type): Capability? {
             post {
                 result == nil || type.isSubtype(of: result.getType()): "incorrect returned capability type"
             }
         }
-        pub fun findFirstPrivateType(_ type: Type): Type?
-        pub fun getAllPrivate(): [Capability]
+        access(all) view fun findFirstPrivateType(_ type: Type): Type?
+        access(Capabilities) fun getAllPrivate(): [Capability]
     }
 
     /// Exposes public Capability retrieval
     ///
-    pub resource interface GetterPublic {
-        pub fun getPublicCapability(_ type: Type): Capability? {
+    access(all) resource interface GetterPublic {
+        access(all) view fun getPublicCapability(_ type: Type): Capability? {
             post {
-                result == nil || type.isSubtype(of: result.getType()): "incorrect returned capability type "
+                result == nil || type.isSubtype(of: result.getType()): "incorrect returned capability type"
             }
         }
 
-        pub fun findFirstPublicType(_ type: Type): Type?
-        pub fun getAllPublic(): [Capability]
+        access(all) view fun findFirstPublicType(_ type: Type): Type?
+        access(all) view fun getAllPublic(): [Capability]
     }
 
     /// This Delegator is used to store Capabilities, partitioned by public and private access with corresponding
     /// GetterPublic and GetterPrivate conformances.AccountCapabilityController
     ///
-    pub resource Delegator: GetterPublic, GetterPrivate {
+    access(all) resource Delegator: GetterPublic, GetterPrivate {
         access(self) let privateCapabilities: {Type: Capability}
         access(self) let publicCapabilities: {Type: Capability}
 
@@ -56,7 +56,7 @@ pub contract CapabilityDelegator {
         //
         /// Returns the public Capability of the given Type if it exists
         ///
-        pub fun getPublicCapability(_ type: Type): Capability? {
+        access(all) view fun getPublicCapability(_ type: Type): Capability? {
             return self.publicCapabilities[type]
         }
 
@@ -66,7 +66,7 @@ pub contract CapabilityDelegator {
         /// @param type: Type of the Capability to retrieve
         /// @return Capability of the given Type if it exists, nil otherwise
         ///
-        pub fun getPrivateCapability(_ type: Type): Capability? {
+        access(Capabilities) view fun getPrivateCapability(_ type: Type): Capability? {
             return self.privateCapabilities[type]
         }
 
@@ -74,7 +74,7 @@ pub contract CapabilityDelegator {
         ///
         /// @return List of all public Capabilities
         ///
-        pub fun getAllPublic(): [Capability] {
+        access(all) view fun getAllPublic(): [Capability] {
             return self.publicCapabilities.values
         }
 
@@ -82,7 +82,7 @@ pub contract CapabilityDelegator {
         ///
         /// @return List of all private Capabilities
         ///
-        pub fun getAllPrivate(): [Capability] {
+        access(Capabilities) fun getAllPrivate(): [Capability] {
             return self.privateCapabilities.values
         }
 
@@ -91,7 +91,7 @@ pub contract CapabilityDelegator {
         /// @param type: Type to check for subtypes
         /// @return First public Type that is a subtype of the given Type, nil otherwise
         ///
-        pub fun findFirstPublicType(_ type: Type): Type? {
+        access(all) view fun findFirstPublicType(_ type: Type): Type? {
             for t in self.publicCapabilities.keys {
                 if t.isSubtype(of: type) {
                     return t
@@ -106,7 +106,7 @@ pub contract CapabilityDelegator {
         /// @param type: Type to check for subtypes
         /// @return First private Type that is a subtype of the given Type, nil otherwise
         ///
-        pub fun findFirstPrivateType(_ type: Type): Type? {
+        access(all) view fun findFirstPrivateType(_ type: Type): Type? {
             for t in self.privateCapabilities.keys {
                 if t.isSubtype(of: type) {
                     return t
@@ -122,7 +122,7 @@ pub contract CapabilityDelegator {
         /// @param cap: Capability to add
         /// @param isPublic: Whether the Capability should be public or private
         ///
-        pub fun addCapability(cap: Capability, isPublic: Bool) {
+        access(Mutate) fun addCapability(cap: Capability, isPublic: Bool) {
             pre {
                 cap.check<&AnyResource>(): "Invalid Capability provided"
             }
@@ -138,7 +138,7 @@ pub contract CapabilityDelegator {
         ///
         /// @param cap: Capability to remove
         ///
-        pub fun removeCapability(cap: Capability) {
+        access(Mutate) fun removeCapability(cap: Capability) {
             if let removedPublic = self.publicCapabilities.remove(key: cap.getType()) {
                 emit DelegatorUpdated(id: self.uuid, capabilityType: cap.getType(), isPublic: true, active: false)
             }
@@ -158,7 +158,7 @@ pub contract CapabilityDelegator {
     /// 
     /// @return Newly created Delegator
     ///
-    pub fun createDelegator(): @Delegator {
+    access(all) fun createDelegator(): @Delegator {
         let delegator <- create Delegator()
         emit DelegatorCreated(id: delegator.uuid)
         return <- delegator

--- a/contracts/CapabilityFactory.cdc
+++ b/contracts/CapabilityFactory.cdc
@@ -23,6 +23,7 @@ access(all) contract CapabilityFactory {
     ///
     access(all) struct interface Factory {
         access(Capabilities) view fun getCapability(acct: auth(Capabilities) &Account, controllerID: UInt64): Capability?
+        access(all) view fun getPublicCapability(acct: auth(Capabilities) &Account, path: PublicPath): Capability?
     }
 
     /// Getter defines an interface for retrieval of a Factory if contained within the implementing resource

--- a/contracts/CapabilityFactory.cdc
+++ b/contracts/CapabilityFactory.cdc
@@ -13,37 +13,37 @@
 /// Capabilities is critical to the use case of Hybrid Custody. It's advised to use Factories sparingly and only for
 /// cases where Capabilities must be castable by the caller.
 ///
-pub contract CapabilityFactory {
+access(all) contract CapabilityFactory {
     
-    pub let StoragePath: StoragePath
-    pub let PrivatePath: PrivatePath
-    pub let PublicPath: PublicPath
+    access(all) let StoragePath: StoragePath
+    access(all) let PrivatePath: PrivatePath
+    access(all) let PublicPath: PublicPath
     
     /// Factory structures a common interface for Capability retrieval from a given account at a specified path
     ///
-    pub struct interface Factory {
-        pub fun getCapability(acct: &AuthAccount, path: CapabilityPath): Capability
+    access(all) struct interface Factory {
+        access(Capabilities) view fun getCapability(acct: auth(Capabilities) &Account, controllerID: UInt64): Capability?
     }
 
     /// Getter defines an interface for retrieval of a Factory if contained within the implementing resource
     ///
-    pub resource interface Getter {
-        pub fun getSupportedTypes(): [Type]
-        pub fun getFactory(_ t: Type): {CapabilityFactory.Factory}?
+    access(all) resource interface Getter {
+        access(all) view fun getSupportedTypes(): [Type]
+        access(all) view fun getFactory(_ t: Type): {CapabilityFactory.Factory}?
     }
 
     /// Manager is a resource that contains Factories and implements the Getter interface for retrieval of contained
     /// Factories
     ///
-    pub resource Manager: Getter {
+    access(all) resource Manager: Getter {
         /// Mapping of Factories indexed on Type of Capability they retrieve
-        pub let factories: {Type: {CapabilityFactory.Factory}}
+        access(all) let factories: {Type: {CapabilityFactory.Factory}}
 
         /// Retrieves a list of Types supported by contained Factories
         ///
         /// @return List of Types supported by the Manager
         ///
-        pub fun getSupportedTypes(): [Type] {
+        access(all) view fun getSupportedTypes(): [Type] {
             return self.factories.keys
         }
 
@@ -51,7 +51,7 @@ pub contract CapabilityFactory {
         ///
         /// @param t: Type the Factory is indexed on
         ///
-        pub fun getFactory(_ t: Type): {CapabilityFactory.Factory}? {
+        access(all) view fun getFactory(_ t: Type): {CapabilityFactory.Factory}? {
             return self.factories[t]
         }
 
@@ -60,7 +60,7 @@ pub contract CapabilityFactory {
         /// @param t: Type of Capability the Factory retrieves
         /// @param f: Factory to add
         ///
-        pub fun addFactory(_ t: Type, _ f: {CapabilityFactory.Factory}) {
+        access(Mutate) fun addFactory(_ t: Type, _ f: {CapabilityFactory.Factory}) {
             pre {
                 !self.factories.containsKey(t): "Factory of given type already exists"
             }
@@ -72,7 +72,7 @@ pub contract CapabilityFactory {
         /// @param t: Type of Capability the Factory retrieves
         /// @param f: Factory to replace existing Factory
         ///
-        pub fun updateFactory(_ t: Type, _ f: {CapabilityFactory.Factory}) {
+        access(Mutate) fun updateFactory(_ t: Type, _ f: {CapabilityFactory.Factory}) {
             self.factories[t] = f
         }
 
@@ -80,7 +80,7 @@ pub contract CapabilityFactory {
         ///
         /// @param t: Type the Factory is indexed on
         ///
-        pub fun removeFactory(_ t: Type): {CapabilityFactory.Factory}? {
+        access(Mutate) fun removeFactory(_ t: Type): {CapabilityFactory.Factory}? {
             return self.factories.remove(key: t)
         }
 
@@ -92,7 +92,7 @@ pub contract CapabilityFactory {
     /// Creates a Manager resource
     ///
     /// @return Manager resource
-    pub fun createFactoryManager(): @Manager {
+    access(all) fun createFactoryManager(): @Manager {
         return <- create Manager()
     }
 

--- a/contracts/CapabilityFilter.cdc
+++ b/contracts/CapabilityFilter.cdc
@@ -6,29 +6,29 @@
 /// - `AllowlistFilter` - A filter which contains a mapping of allowed Types
 /// - `AllowAllFilter`  - A passthrough, all requested capabilities are allowed
 /// 
-pub contract CapabilityFilter {
+access(all) contract CapabilityFilter {
     
     /* --- Canonical Paths --- */
     //
-    pub let StoragePath: StoragePath
-    pub let PublicPath: PublicPath
-    pub let PrivatePath: PrivatePath
+    access(all) let StoragePath: StoragePath
+    access(all) let PublicPath: PublicPath
+    access(all) let PrivatePath: PrivatePath
 
     /* --- Events --- */
     //
-    pub event FilterUpdated(id: UInt64, filterType: Type, type: Type, active: Bool)
+    access(all) event FilterUpdated(id: UInt64, filterType: Type, type: Type, active: Bool)
 
     /// `Filter` is a simple interface with methods to determine if a Capability is allowed and retrieve details about
     /// the Filter itself
     ///
-    pub resource interface Filter {
-        pub fun allowed(cap: Capability): Bool
-        pub fun getDetails(): AnyStruct
+    access(all) resource interface Filter {
+        access(all) view fun allowed(cap: Capability): Bool
+        access(all) view fun getDetails(): AnyStruct
     }
 
     /// `DenylistFilter` is a `Filter` which contains a mapping of denied Types
     ///
-    pub resource DenylistFilter: Filter {
+    access(all) resource DenylistFilter: Filter {
 
         /// Represents the underlying types which should not ever be returned by a RestrictedChildAccount. The filter
         /// will borrow a requested capability, and make sure that the type it gets back is not in the list of denied
@@ -39,7 +39,7 @@ pub contract CapabilityFilter {
         /// 
         /// @param type: The type to add to the denied types mapping
         ///
-        pub fun addType(_ type: Type) {
+        access(Mutate) fun addType(_ type: Type) {
             self.deniedTypes.insert(key: type, true)
             emit FilterUpdated(id: self.uuid, filterType: self.getType(), type: type, active: true)
         }
@@ -48,7 +48,7 @@ pub contract CapabilityFilter {
         ///
         /// @param type: The type to remove from the denied types mapping
         ///
-        pub fun removeType(_ type: Type) {
+        access(Mutate) fun removeType(_ type: Type) {
             if let removed = self.deniedTypes.remove(key: type) {
                 emit FilterUpdated(id: self.uuid, filterType: self.getType(), type: type, active: false)
             }
@@ -56,7 +56,7 @@ pub contract CapabilityFilter {
 
         /// Removes all types from the mapping of denied types
         ///
-        pub fun removeAllTypes() {
+        access(Mutate) fun removeAllTypes() {
             for type in self.deniedTypes.keys {
                 self.removeType(type)
             }
@@ -67,7 +67,7 @@ pub contract CapabilityFilter {
         /// @param cap: The capability to check
         /// @return: true if the capability is allowed, false otherwise
         ///
-        pub fun allowed(cap: Capability): Bool {
+        access(all) view fun allowed(cap: Capability): Bool {
             if let item = cap.borrow<&AnyResource>() {
                 return !self.deniedTypes.containsKey(item.getType())
             }
@@ -80,7 +80,7 @@ pub contract CapabilityFilter {
         /// @return A struct containing details about this filter including this Filter's Type indexed on the `type`
         ///         key as well as types denied indexed on the `deniedTypes` key
         ///
-        pub fun getDetails(): AnyStruct {
+        access(all) view fun getDetails(): AnyStruct {
             return {
                 "type": self.getType(),
                 "deniedTypes": self.deniedTypes.keys
@@ -94,7 +94,7 @@ pub contract CapabilityFilter {
 
     /// `AllowlistFilter` is a `Filter` which contains a mapping of allowed Types
     ///
-    pub resource AllowlistFilter: Filter {
+    access(all) resource AllowlistFilter: Filter {
         // allowedTypes
         // Represents the set of underlying types which are allowed to be 
         // returned by a RestrictedChildAccount. The filter will borrow
@@ -106,7 +106,7 @@ pub contract CapabilityFilter {
         /// 
         /// @param type: The type to add to the allowed types mapping
         ///
-        pub fun addType(_ type: Type) {
+        access(Mutate) fun addType(_ type: Type) {
             self.allowedTypes.insert(key: type, true)
             emit FilterUpdated(id: self.uuid, filterType: self.getType(), type: type, active: true)
         }
@@ -115,7 +115,7 @@ pub contract CapabilityFilter {
         ///
         /// @param type: The type to remove from the denied types mapping
         ///
-        pub fun removeType(_ type: Type) {
+        access(Mutate) fun removeType(_ type: Type) {
             if let removed = self.allowedTypes.remove(key: type) {
                 emit FilterUpdated(id: self.uuid, filterType: self.getType(), type: type, active: false)
             }
@@ -123,7 +123,7 @@ pub contract CapabilityFilter {
 
         /// Removes all types from the mapping of denied types
         ///
-        pub fun removeAllTypes() {
+        access(Mutate) fun removeAllTypes() {
             for type in self.allowedTypes.keys {
                 self.removeType(type)
             }
@@ -134,7 +134,7 @@ pub contract CapabilityFilter {
         /// @param cap: The capability to check
         /// @return: true if the capability is allowed, false otherwise
         ///
-        pub fun allowed(cap: Capability): Bool {
+        access(all) view fun allowed(cap: Capability): Bool {
             if let item = cap.borrow<&AnyResource>() {
                 return self.allowedTypes.containsKey(item.getType())
             }
@@ -147,7 +147,7 @@ pub contract CapabilityFilter {
         /// @return A struct containing details about this filter including this Filter's Type indexed on the `type`
         ///         key as well as types allowed indexed on the `allowedTypes` key
         ///
-        pub fun getDetails(): AnyStruct {
+        access(all) view fun getDetails(): AnyStruct {
             return {
                 "type": self.getType(),
                 "allowedTypes": self.allowedTypes.keys
@@ -161,13 +161,13 @@ pub contract CapabilityFilter {
 
     /// AllowAllFilter is a passthrough, all requested capabilities are allowed
     ///
-    pub resource AllowAllFilter: Filter {
+    access(all) resource AllowAllFilter: Filter {
         /// Determines if a requested capability is allowed by this `Filter`
         ///
         /// @param cap: The capability to check
         /// @return: true since this filter is a passthrough
         ///
-        pub fun allowed(cap: Capability): Bool {
+        access(all) view fun allowed(cap: Capability): Bool {
             return true
         }
         
@@ -176,7 +176,7 @@ pub contract CapabilityFilter {
         /// @return A struct containing details about this filter including this Filter's Type indexed on the `type`
         ///         key
         ///
-        pub fun getDetails(): AnyStruct {
+        access(all) view fun getDetails(): AnyStruct {
             return {
                 "type": self.getType()
             }
@@ -188,7 +188,7 @@ pub contract CapabilityFilter {
     /// @param t: The type of `Filter` to create
     /// @return: A new instance of the given `Filter` type
     ///
-    pub fun create(_ t: Type): @AnyResource{Filter} {
+    access(all) fun createFilter(_ t: Type): @{Filter} {
         post {
             result.getType() == t
         }

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -201,7 +201,7 @@ access(all) contract HybridCustody {
     ///
     access(all) resource interface AccountPublic {
         // TODO: This has been disabled because you cannot get a capability without providing a type T anymore in Cadence 1.0
-        // access(all) view fun getPublicCapability(path: PublicPath, type: Type): Capability?
+        access(all) view fun getPublicCapability(path: PublicPath, type: Type): Capability?
         access(all) view fun getPublicCapFromDelegator(type: Type): Capability?
         access(all) view fun getAddress(): Address
         access(all) view fun getCapabilityFactoryManager(): &{CapabilityFactory.Getter}?
@@ -629,14 +629,20 @@ access(all) contract HybridCustody {
             return nil
         }
 
-        /// TODO: This has been disabled because you cannot get a capability without providing a type T anymore in Cadence 1.0
-        //
         /// Enables retrieval of public Capabilities of the given type from the specified path or nil if none is found.
         /// Callers should be aware this method uses the `CapabilityFactory` retrieval path.
         ///
-        // access(all) view fun getPublicCapability(path: PublicPath, type: Type): Capability? {
-        //     return self.getCapability(path: path, type: type)
-        // }
+        access(all) view fun getPublicCapability(path: PublicPath, type: Type): Capability? {
+            let child = self.childCap.borrow() ?? panic("failed to borrow child account")
+
+            let f = self.factory.borrow()!.getFactory(type)
+            if f == nil {
+                return nil
+            }
+
+            let acct = child.borrowAccount()
+            return f!.getPublicCapability(acct: acct, path: path)
+        }
 
         /// Returns a reference to the stored managerCapabilityFilter if one exists
         ///

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -507,12 +507,6 @@ access(all) contract HybridCustody {
                 self.ownedAccounts.length == 0: "cannot destroy a manager with owned accounts"
             }
 
-            let keys = self.resources.keys
-            for k in keys {
-                let r <- self.resources.remove(key: k)!
-                Burner.burn(<-r)
-            }
-
             for c in self.childAccounts.keys {
                 self.removeChild(addr: c)
             }
@@ -676,9 +670,7 @@ access(all) contract HybridCustody {
         ///
         access(contract) fun setRedeemed(_ addr: Address) {
             let acct = self.childCap.borrow()!._borrowAccount()
-            if let o = acct.storage.borrow<&OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) {
-                o.setRedeemed(addr)
-            }
+            acct.storage.borrow<&OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)?.setRedeemed(addr)
         }
 
         /// Returns a reference to the stored delegator, generally used for arbitrary Capability retrieval

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -1,5 +1,6 @@
 // Third-party imports
 import "MetadataViews"
+import "ViewResolver"
 
 // HC-owned imports
 import "CapabilityFactory"
@@ -27,39 +28,42 @@ import "CapabilityFilter"
 ///
 /// Repo reference: https://github.com/onflow/hybrid-custody
 ///
-pub contract HybridCustody {
+access(all) contract HybridCustody {
+
+    access(all) entitlement Restricted
+    access(all) entitlement Owner
 
     /* --- Canonical Paths --- */
     //
     // Note: Paths for ChildAccount & Delegator are derived from the parent's address
     //
-    pub let OwnedAccountStoragePath: StoragePath
-    pub let OwnedAccountPublicPath: PublicPath
-    pub let OwnedAccountPrivatePath: PrivatePath
+    access(all) let OwnedAccountStoragePath: StoragePath
+    access(all) let OwnedAccountPublicPath: PublicPath
+    access(all) let OwnedAccountPrivatePath: PrivatePath
 
-    pub let ManagerStoragePath: StoragePath
-    pub let ManagerPublicPath: PublicPath
-    pub let ManagerPrivatePath: PrivatePath
+    access(all) let ManagerStoragePath: StoragePath
+    access(all) let ManagerPublicPath: PublicPath
+    access(all) let ManagerPrivatePath: PrivatePath
 
-    pub let LinkedAccountPrivatePath: PrivatePath
-    pub let BorrowableAccountPrivatePath: PrivatePath
+    access(all) let LinkedAccountPrivatePath: PrivatePath
+    access(all) let BorrowableAccountPrivatePath: PrivatePath
 
     /* --- Events --- */
     //
     /// Manager creation event
-    pub event CreatedManager(id: UInt64)
+    access(all) event CreatedManager(id: UInt64)
     /// OwnedAccount creation event
-    pub event CreatedOwnedAccount(id: UInt64, child: Address)
+    access(all) event CreatedOwnedAccount(id: UInt64, child: Address)
     /// ChildAccount added/removed from Manager
     ///     active  : added to Manager
     ///     !active : removed from Manager
-    pub event AccountUpdated(id: UInt64?, child: Address, parent: Address, active: Bool)
+    access(all) event AccountUpdated(id: UInt64?, child: Address, parent: Address, active: Bool)
     /// OwnedAccount added/removed or sealed
     ///     active && owner != nil  : added to Manager 
     ///     !active && owner == nil : removed from Manager
-    pub event OwnershipUpdated(id: UInt64, child: Address, previousOwner: Address?, owner: Address?, active: Bool)
+    access(all) event OwnershipUpdated(id: UInt64, child: Address, previousOwner: Address?, owner: Address?, active: Bool)
     /// ChildAccount ready to be redeemed by emitted pendingParent
-    pub event ChildAccountPublished(
+    access(all) event ChildAccountPublished(
         ownedAcctID: UInt64,
         childAcctID: UInt64,
         capDelegatorID: UInt64,
@@ -70,30 +74,30 @@ pub contract HybridCustody {
         pendingParent: Address
     )
     /// OwnedAccount granted ownership to a new address, publishing a Capability for the pendingOwner
-    pub event OwnershipGranted(ownedAcctID: UInt64, child: Address, previousOwner: Address?, pendingOwner: Address)
+    access(all) event OwnershipGranted(ownedAcctID: UInt64, child: Address, previousOwner: Address?, pendingOwner: Address)
     /// Account has been sealed - keys revoked, new AuthAccount Capability generated
-    pub event AccountSealed(id: UInt64, address: Address, parents: [Address])
+    access(all) event AccountSealed(id: UInt64, address: Address, parents: [Address])
 
     /// An OwnedAccount shares the BorrowableAccount capability to itelf with ChildAccount resources
     ///
-    pub resource interface BorrowableAccount {
-        access(contract) fun borrowAccount(): &AuthAccount
-        pub fun check(): Bool
+    access(all) resource interface BorrowableAccount {
+        access(contract) view fun borrowAccount(): auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account
+        access(all) view fun check(): Bool
     }
 
     /// Public methods anyone can call on an OwnedAccount
     ///
-    pub resource interface OwnedAccountPublic {
+    access(all) resource interface OwnedAccountPublic {
         /// Returns the addresses of all parent accounts
-        pub fun getParentAddresses(): [Address]
+        access(all) view fun getParentAddresses(): [Address]
 
         /// Returns associated parent addresses and their redeemed status - true if redeemed, false if pending
-        pub fun getParentStatuses(): {Address: Bool}
+        access(all) view fun getParentStatuses(): {Address: Bool}
 
         /// Returns true if the given address is a parent of this child and has redeemed it. Returns false if the given
         /// address is a parent of this child and has NOT redeemed it. Returns nil if the given address it not a parent
         /// of this child account.
-        pub fun getRedeemedStatus(addr: Address): Bool?
+        access(all) view fun getRedeemedStatus(addr: Address): Bool?
 
         /// A callback function to mark a parent as redeemed on the child account.
         access(contract) fun setRedeemed(_ addr: Address)
@@ -101,18 +105,18 @@ pub contract HybridCustody {
 
     /// Private interface accessible to the owner of the OwnedAccount
     ///
-    pub resource interface OwnedAccountPrivate {
+    access(all) resource interface OwnedAccountPrivate {
         /// Deletes the ChildAccount resource being used to share access to this OwnedAccount with the supplied parent
         /// address, and unlinks the paths it was using to reach the underlying account.
-        pub fun removeParent(parent: Address): Bool
+        access(Restricted) fun removeParent(parent: Address): Bool
 
         /// Sets up a new ChildAccount resource for the given parentAddress to redeem. This child account uses the
         /// supplied factory and filter to manage what can be obtained from the child account, and a new
         /// CapabilityDelegator resource is created for the sharing of one-off capabilities. Each of these pieces of
         /// access control are managed through the child account.
-        pub fun publishToParent(
+        access(Restricted) fun publishToParent(
             parentAddress: Address,
-            factory: Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>,
+            factory: Capability<&{CapabilityFactory.Getter}>,
             filter: Capability<&{CapabilityFilter.Filter}>
         ) {
             pre {
@@ -124,7 +128,7 @@ pub contract HybridCustody {
         /// Passes ownership of this child account to the given address. Once executed, all active keys on the child
         /// account will be revoked, and the active AuthAccount Capability being used by to obtain capabilities will be
         /// rotated, preventing anyone without the newly generated Capability from gaining access to the account.
-        pub fun giveOwnership(to: Address)
+        access(Owner) fun giveOwnership(to: Address)
 
         /// Revokes all keys on an account, unlinks all currently active AuthAccount capabilities, then makes a new one
         /// and replaces the OwnedAccount's underlying AuthAccount Capability with the new one to ensure that all
@@ -132,12 +136,12 @@ pub contract HybridCustody {
         /// Unless this method is executed via the giveOwnership function, this will leave an account **without** an
         /// owner.
         /// USE WITH EXTREME CAUTION.
-        pub fun seal()
+        access(Owner) fun seal()
 
         // setCapabilityFactoryForParent
         // Override the existing CapabilityFactory Capability for a given parent. This will allow the owner of the
         // account to start managing their own factory of capabilities to be able to retrieve
-        pub fun setCapabilityFactoryForParent(parent: Address, cap: Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>) {
+        access(Restricted) fun setCapabilityFactoryForParent(parent: Address, cap: Capability<&{CapabilityFactory.Getter}>) {
             pre {
                 cap.check(): "Invalid CapabilityFactory.Getter Capability provided"
             }
@@ -145,7 +149,7 @@ pub contract HybridCustody {
 
         /// Override the existing CapabilityFilter Capability for a given parent. This will allow the owner of the
         /// account to start managing their own filter for retrieving Capabilities on Private Paths
-        pub fun setCapabilityFilterForParent(parent: Address, cap: Capability<&{CapabilityFilter.Filter}>) {
+        access(Restricted) fun setCapabilityFilterForParent(parent: Address, cap: Capability<&{CapabilityFilter.Filter}>) {
             pre {
                 cap.check(): "Invalid CapabilityFilter Capability provided"
             }
@@ -153,68 +157,67 @@ pub contract HybridCustody {
 
         /// Adds a capability to a parent's managed @ChildAccount resource. The Capability can be made public,
         /// permitting anyone to borrow it.
-        pub fun addCapabilityToDelegator(parent: Address, cap: Capability, isPublic: Bool) {
+        access(Restricted) fun addCapabilityToDelegator(parent: Address, cap: Capability, isPublic: Bool) {
             pre {
                 cap.check<&AnyResource>(): "Invalid Capability provided"
             }
         }
 
         /// Removes a Capability from the CapabilityDelegator used by the specified parent address
-        pub fun removeCapabilityFromDelegator(parent: Address, cap: Capability)
+        access(Restricted) fun removeCapabilityFromDelegator(parent: Address, cap: Capability)
 
         /// Returns the address of this OwnedAccount
-        pub fun getAddress(): Address
+        access(all) view fun getAddress(): Address
         
         /// Checks if this OwnedAccount is a child of the specified address
-        pub fun isChildOf(_ addr: Address): Bool
+        access(all) view fun isChildOf(_ addr: Address): Bool
 
         /// Returns all addresses which are parents of this OwnedAccount
-        pub fun getParentAddresses(): [Address]
+        access(all) view fun getParentAddresses(): [Address]
 
         /// Borrows this OwnedAccount's AuthAccount Capability
-        pub fun borrowAccount(): &AuthAccount?
+        access(contract) view fun borrowAccount(): auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account
 
         /// Returns the current owner of this account, if there is one
-        pub fun getOwner(): Address?
+        access(all) view fun getOwner(): Address?
 
         /// Returns the pending owner of this account, if there is one
-        pub fun getPendingOwner(): Address?
+        access(all) view fun getPendingOwner(): Address?
 
         /// A callback which is invoked when a parent redeems an owned account
         access(contract) fun setOwnerCallback(_ addr: Address)
         
         /// Destroys all outstanding AuthAccount capabilities on this owned account, and creates a new one for the
         /// OwnedAccount to use
-        pub fun rotateAuthAccount()
+        access(Owner) fun rotateAuthAccount()
 
         /// Revokes all keys on this account
-        pub fun revokeAllKeys()
+        access(Owner) fun revokeAllKeys()
     }
 
     /// Public methods exposed on a ChildAccount resource. OwnedAccountPublic will share some methods here, but isn't
     /// necessarily the same.
     ///
-    pub resource interface AccountPublic {
-        pub fun getPublicCapability(path: PublicPath, type: Type): Capability?
-        pub fun getPublicCapFromDelegator(type: Type): Capability?
-        pub fun getAddress(): Address
-        pub fun getCapabilityFactoryManager(): &{CapabilityFactory.Getter}?
-        pub fun getCapabilityFilter(): &{CapabilityFilter.Filter}?
+    access(all) resource interface AccountPublic {
+        // TODO: This has been disabled because you cannot get a capability without providing a type T anymore in Cadence 1.0
+        // access(all) view fun getPublicCapability(path: PublicPath, type: Type): Capability?
+        access(all) view fun getPublicCapFromDelegator(type: Type): Capability?
+        access(all) view fun getAddress(): Address
+        access(all) view fun getCapabilityFactoryManager(): &{CapabilityFactory.Getter}?
+        access(all) view fun getCapabilityFilter(): &{CapabilityFilter.Filter}?
     }
 
     /// Methods accessible to the designated parent of a ChildAccount
     ///
-    pub resource interface AccountPrivate {
-        pub fun getCapability(path: CapabilityPath, type: Type): Capability? {
+    access(all) resource interface AccountPrivate {
+        access(Capabilities) view fun getCapability(controllerID: UInt64, type: Type): Capability? {
             post {
                 result == nil || [true, nil].contains(self.getManagerCapabilityFilter()?.allowed(cap: result!)):
                     "Capability is not allowed by this account's Parent"
             }
         }
-        pub fun getPublicCapability(path: PublicPath, type: Type): Capability?
-        pub fun getManagerCapabilityFilter():  &{CapabilityFilter.Filter}?
-        pub fun getPublicCapFromDelegator(type: Type): Capability?
-        pub fun getPrivateCapFromDelegator(type: Type): Capability? {
+        access(all) view fun getManagerCapabilityFilter():  &{CapabilityFilter.Filter}?
+        access(Capabilities) view fun getPrivateCapFromDelegator(type: Type): Capability? {
             post {
                 result == nil || [true, nil].contains(self.getManagerCapabilityFilter()?.allowed(cap: result!)):
                     "Capability is not allowed by this account's Parent"
@@ -231,14 +234,14 @@ pub contract HybridCustody {
 
     /// Entry point for a parent to obtain, maintain and access Capabilities or perform other actions on child accounts
     ///
-    pub resource interface ManagerPrivate {
-        pub fun addAccount(cap: Capability<&{AccountPrivate, AccountPublic, MetadataViews.Resolver}>)
-        pub fun borrowAccount(addr: Address): &{AccountPrivate, AccountPublic, MetadataViews.Resolver}?
-        pub fun removeChild(addr: Address)
-        pub fun addOwnedAccount(cap: Capability<&{OwnedAccountPrivate, OwnedAccountPublic, MetadataViews.Resolver}>)
-        pub fun borrowOwnedAccount(addr: Address): &{OwnedAccountPrivate, OwnedAccountPublic, MetadataViews.Resolver}?
-        pub fun removeOwned(addr: Address)
-        pub fun setManagerCapabilityFilter(cap: Capability<&{CapabilityFilter.Filter}>?, childAddress: Address) {
+    access(all) resource interface ManagerPrivate {
+        access(Restricted) fun addAccount(cap: Capability<&{AccountPrivate, AccountPublic, ViewResolver.Resolver}>)
+        access(Restricted) fun borrowAccount(addr: Address): &{AccountPrivate, AccountPublic, ViewResolver.Resolver}?
+        access(Restricted) fun removeChild(addr: Address)
+        access(Owner) fun addOwnedAccount(cap: Capability<auth(Owner) &{OwnedAccountPrivate, OwnedAccountPublic, ViewResolver.Resolver}>)
+        access(Restricted) fun borrowOwnedAccount(addr: Address): &{OwnedAccountPrivate, OwnedAccountPublic, ViewResolver.Resolver}?
+        access(Restricted) fun removeOwned(addr: Address)
+        access(Restricted) fun setManagerCapabilityFilter(cap: Capability<&{CapabilityFilter.Filter}>?, childAddress: Address) {
             pre {
                 cap == nil || cap!.check(): "Invalid Manager Capability Filter"
             }
@@ -247,39 +250,39 @@ pub contract HybridCustody {
 
     /// Functions anyone can call on a manager to get information about an account such as What child accounts it has
     /// Functions anyone can call on a manager to get information about an account such as what child accounts it has
-    pub resource interface ManagerPublic {
-        pub fun borrowAccountPublic(addr: Address): &{AccountPublic, MetadataViews.Resolver}?
-        pub fun getChildAddresses(): [Address]
-        pub fun getOwnedAddresses(): [Address]
-        pub fun getChildAccountDisplay(address: Address): MetadataViews.Display?
+    access(all) resource interface ManagerPublic {
+        access(all) fun borrowAccountPublic(addr: Address): &{AccountPublic, ViewResolver.Resolver}?
+        access(all) fun getChildAddresses(): [Address]
+        access(all) fun getOwnedAddresses(): [Address]
+        access(all) fun getChildAccountDisplay(address: Address): MetadataViews.Display?
         access(contract) fun removeParentCallback(child: Address)
     }
 
     /// A resource for an account which fills the Parent role of the Child-Parent account management Model. A Manager
     /// can redeem or remove child accounts, and obtain any capabilities exposed by the child account to them.
     ///
-    pub resource Manager: ManagerPrivate, ManagerPublic, MetadataViews.Resolver {
+    access(all) resource Manager: ManagerPrivate, ManagerPublic, ViewResolver.Resolver {
 
         /// Mapping of restricted access child account Capabilities indexed by their address
-        pub let childAccounts: {Address: Capability<&{AccountPrivate, AccountPublic, MetadataViews.Resolver}>}
+        access(self) let childAccounts: {Address: Capability<&{AccountPrivate, AccountPublic, ViewResolver.Resolver}>}
         /// Mapping of unrestricted owned account Capabilities indexed by their address
-        pub let ownedAccounts: {Address: Capability<&{OwnedAccountPrivate, OwnedAccountPublic, MetadataViews.Resolver}>}
+        access(self) let ownedAccounts: {Address: Capability<auth(Owner) &{OwnedAccountPrivate, OwnedAccountPublic, ViewResolver.Resolver}>}
 
         /// A bucket of structs so that the Manager resource can be easily extended with new functionality.
-        pub let data: {String: AnyStruct}
+        access(self) let data: {String: AnyStruct}
         /// A bucket of resources so that the Manager resource can be easily extended with new functionality.
-        pub let resources: @{String: AnyResource}
+        access(self) let resources: @{String: AnyResource}
 
         /// An optional filter to gate what capabilities are permitted to be returned from a child account For example,
         /// Dapper Wallet parent account's should not be able to retrieve any FungibleToken Provider capabilities.
-        pub var filter: Capability<&{CapabilityFilter.Filter}>?
+        access(self) var filter: Capability<&{CapabilityFilter.Filter}>?
 
         // display metadata for a child account exists on its parent
-        pub let childAccountDisplays: {Address: MetadataViews.Display}
+        access(self) let childAccountDisplays: {Address: MetadataViews.Display}
 
         /// Sets the Display on the ChildAccount. If nil, the display is removed.
         ///
-        pub fun setChildAccountDisplay(address: Address, _ d: MetadataViews.Display?) {
+        access(Restricted) fun setChildAccountDisplay(address: Address, _ d: MetadataViews.Display?) {
             pre {
                 self.childAccounts[address] != nil: "There is no child account with this address"
             }
@@ -295,7 +298,7 @@ pub contract HybridCustody {
         /// Adds a ChildAccount Capability to this Manager. If a default Filter is set in the manager, it will also be
         /// added to the ChildAccount
         ///
-        pub fun addAccount(cap: Capability<&{AccountPrivate, AccountPublic, MetadataViews.Resolver}>) {
+        access(Restricted) fun addAccount(cap: Capability<&{AccountPrivate, AccountPublic, ViewResolver.Resolver}>) {
             pre {
                 self.childAccounts[cap.address] == nil: "There is already a child account with this address"
             }
@@ -313,7 +316,7 @@ pub contract HybridCustody {
 
         /// Sets the default Filter Capability for this Manager. Does not propagate to child accounts.
         ///
-        pub fun setDefaultManagerCapabilityFilter(cap: Capability<&{CapabilityFilter.Filter}>?) {
+        access(Restricted) fun setDefaultManagerCapabilityFilter(cap: Capability<&{CapabilityFilter.Filter}>?) {
             pre {
                 cap == nil || cap!.check(): "supplied capability must be nil or check must pass"
             }
@@ -323,7 +326,7 @@ pub contract HybridCustody {
         
         /// Sets the Filter Capability for this Manager, propagating to the specified child account
         ///
-        pub fun setManagerCapabilityFilter(cap: Capability<&{CapabilityFilter.Filter}>?, childAddress: Address) {
+        access(Restricted) fun setManagerCapabilityFilter(cap: Capability<&{CapabilityFilter.Filter}>?, childAddress: Address) {
             let acct = self.borrowAccount(addr: childAddress) 
                 ?? panic("child account not found")
 
@@ -333,7 +336,7 @@ pub contract HybridCustody {
         /// Removes specified child account from the Manager's child accounts. Callbacks to the child account remove
         /// any associated resources and Capabilities
         ///
-        pub fun removeChild(addr: Address) {
+        access(Restricted) fun removeChild(addr: Address) {
             let cap = self.childAccounts.remove(key: addr)
                 ?? panic("child account not found")
 
@@ -365,7 +368,7 @@ pub contract HybridCustody {
         /// Adds an owned account to the Manager's list of owned accounts, setting the Manager account as the owner of
         /// the given account
         ///
-        pub fun addOwnedAccount(cap: Capability<&{OwnedAccountPrivate, OwnedAccountPublic, MetadataViews.Resolver}>) {
+        access(Owner) fun addOwnedAccount(cap: Capability<auth(Owner) &{OwnedAccountPrivate, OwnedAccountPublic, ViewResolver.Resolver}>) {
             pre {
                 self.ownedAccounts[cap.address] == nil: "There is already an owned account with this address"
             }
@@ -386,7 +389,7 @@ pub contract HybridCustody {
 
         /// Returns a reference to a child account
         ///
-        pub fun borrowAccount(addr: Address): &{AccountPrivate, AccountPublic, MetadataViews.Resolver}? {
+        access(Restricted) fun borrowAccount(addr: Address): &{AccountPrivate, AccountPublic, ViewResolver.Resolver}? {
             let cap = self.childAccounts[addr]
             if cap == nil {
                 return nil
@@ -397,7 +400,7 @@ pub contract HybridCustody {
 
         /// Returns a reference to a child account's public AccountPublic interface
         ///
-        pub fun borrowAccountPublic(addr: Address): &{AccountPublic, MetadataViews.Resolver}? {
+        access(all) fun borrowAccountPublic(addr: Address): &{AccountPublic, ViewResolver.Resolver}? {
             let cap = self.childAccounts[addr]
             if cap == nil {
                 return nil
@@ -408,7 +411,7 @@ pub contract HybridCustody {
 
         /// Returns a reference to an owned account
         ///
-        pub fun borrowOwnedAccount(addr: Address): &{OwnedAccountPrivate, OwnedAccountPublic, MetadataViews.Resolver}? {
+        access(Restricted) fun borrowOwnedAccount(addr: Address): &{OwnedAccountPrivate, OwnedAccountPublic, ViewResolver.Resolver}? {
             if let cap = self.ownedAccounts[addr] {
                 return cap.borrow()
             }
@@ -419,7 +422,7 @@ pub contract HybridCustody {
         /// Removes specified child account from the Manager's child accounts. Callbacks to the child account remove
         /// any associated resources and Capabilities
         ///
-        pub fun removeOwned(addr: Address) {
+        access(Restricted) fun removeOwned(addr: Address) {
             if let acct = self.ownedAccounts.remove(key: addr) {
                 if acct.check() {
                     acct.borrow()!.seal()
@@ -439,7 +442,7 @@ pub contract HybridCustody {
         /// mechanism intended to easily transfer 'root' access on this account to another account and an attempt to
         /// minimize access vectors.
         ///
-        pub fun giveOwnership(addr: Address, to: Address) {
+        access(Owner) fun giveOwnership(addr: Address, to: Address) {
             let acct = self.ownedAccounts.remove(key: addr)
                 ?? panic("account not found")
 
@@ -448,31 +451,31 @@ pub contract HybridCustody {
 
         /// Returns an array of child account addresses
         ///
-        pub fun getChildAddresses(): [Address] {
+        access(all) view fun getChildAddresses(): [Address] {
             return self.childAccounts.keys
         }
 
         /// Returns an array of owned account addresses
         ///
-        pub fun getOwnedAddresses(): [Address] {
+        access(all) view fun getOwnedAddresses(): [Address] {
             return self.ownedAccounts.keys
         }
 
         /// Retrieves the parent-defined display for the given child account
         ///
-        pub fun getChildAccountDisplay(address: Address): MetadataViews.Display? {
+        access(all) view fun getChildAccountDisplay(address: Address): MetadataViews.Display? {
             return self.childAccountDisplays[address]
         }
 
         /// Returns the types of supported views - none at this time
         ///
-        pub fun getViews(): [Type] {
+        access(all) view fun getViews(): [Type] {
             return []
         }
 
         /// Resolves the given view if supported - none at this time
         ///
-        pub fun resolveView(_ view: Type): AnyStruct? {
+        access(all) view fun resolveView(_ view: Type): AnyStruct? {
             return nil
         }
 
@@ -489,9 +492,10 @@ pub contract HybridCustody {
             self.resources <- {}
         }
 
-        destroy () {
-            destroy self.resources
-        }
+        // TODO: burnCallback and ResourceDestroyed event
+        // destroy () {
+        //     destroy self.resources
+        // }
     }
 
     /// The ChildAccount resource sits between a child account and a parent and is stored on the same account as the
@@ -503,27 +507,27 @@ pub contract HybridCustody {
     /// able to manage all ChildAccount resources it shares, without worrying about whether the upstream parent can do
     /// anything to prevent it.
     /// 
-    pub resource ChildAccount: AccountPrivate, AccountPublic, MetadataViews.Resolver {
+    access(all) resource ChildAccount: AccountPrivate, AccountPublic, ViewResolver.Resolver {
         /// A Capability providing access to the underlying child account
-        access(self) let childCap: Capability<&{BorrowableAccount, OwnedAccountPublic, MetadataViews.Resolver}>
+        access(self) let childCap: Capability<&{BorrowableAccount, OwnedAccountPublic, ViewResolver.Resolver}>
 
         /// The CapabilityFactory Manager is a ChildAccount's way of limiting what types can be asked for by its parent
         /// account. The CapabilityFactory returns Capabilities which can be casted to their appropriate types once
         /// obtained, but only if the child account has configured their factory to allow it. For instance, a
         /// ChildAccount might choose to expose NonFungibleToken.Provider, but not FungibleToken.Provider
-        pub var factory: Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>
+        access(self) var factory: Capability<&{CapabilityFactory.Getter}>
 
         /// The CapabilityFilter is a restriction put at the front of obtaining any non-public Capability. Some wallets
         /// might want to give access to NonFungibleToken.Provider, but only to **some** of the collections it manages,
         /// not all of them.
-        pub var filter: Capability<&{CapabilityFilter.Filter}>
+        access(self) var filter: Capability<&{CapabilityFilter.Filter}>
 
         /// The CapabilityDelegator is a way to share one-off capabilities from the child account. These capabilities
         /// can be public OR private and are separate from the factory which returns a capability at a given path as a 
         /// certain type. When using the CapabilityDelegator, you do not have the ability to specify which path a
         /// capability came from. For instance, Dapper Wallet might choose to expose a Capability to their Full TopShot
         /// collection, but only to the path that the collection exists in.
-        pub let delegator: Capability<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPublic, CapabilityDelegator.GetterPrivate}>
+        access(self) let delegator: Capability<auth(Capabilities) &{CapabilityDelegator.GetterPublic, CapabilityDelegator.GetterPrivate}>
 
         /// managerCapabilityFilter is a component optionally given to a child account when a manager redeems it. If
         /// this filter is not nil, any Capability returned through the `getCapability` function checks that the
@@ -538,11 +542,11 @@ pub contract HybridCustody {
 
         /// ChildAccount resources have a 1:1 association with parent accounts, the named parent Address here is the 
         /// one with a Capability on this resource.
-        pub let parent: Address
+        access(all) let parent: Address
 
         /// Returns the Address of the underlying child account
         ///
-        pub fun getAddress(): Address {
+        access(all) view fun getAddress(): Address {
             return self.childCap.address
         }
 
@@ -562,13 +566,13 @@ pub contract HybridCustody {
 
         /// Sets the CapabiltyFactory.Manager Capability
         ///
-        pub fun setCapabilityFactory(cap: Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>) {
+        access(Restricted) fun setCapabilityFactory(cap: Capability<&{CapabilityFactory.Getter}>) {
             self.factory = cap
         }
  
         /// Sets the Filter Capability as the one provided
         ///
-        pub fun setCapabilityFilter(cap: Capability<&{CapabilityFilter.Filter}>) {
+        access(Restricted) fun setCapabilityFilter(cap: Capability<&{CapabilityFilter.Filter}>) {
             self.filter = cap
         }
 
@@ -579,7 +583,7 @@ pub contract HybridCustody {
         /// Capabilities, see `getPrivateCapFromDelegator()` and `getPublicCapFromDelegator()` which use the
         /// `Delegator` retrieval path.
         ///
-        pub fun getCapability(path: CapabilityPath, type: Type): Capability? {
+        access(Capabilities) view fun getCapability(controllerID: UInt64, type: Type): Capability? {
             let child = self.childCap.borrow() ?? panic("failed to borrow child account")
 
             let f = self.factory.borrow()!.getFactory(type)
@@ -588,14 +592,15 @@ pub contract HybridCustody {
             }
 
             let acct = child.borrowAccount()
-            let cap = f!.getCapability(acct: acct, path: path)
+            let tmp = f!.getCapability(acct: acct, controllerID: controllerID)
+            if tmp == nil {
+                return nil
+            }
 
+            let cap = tmp!
             // Check that private capabilities are allowed by either internal or manager filter (if assigned)
             // If not allowed, return nil
-            if path.getType() == Type<PrivatePath>() && (
-                self.filter.borrow()!.allowed(cap: cap) == false || 
-                (self.getManagerCapabilityFilter()?.allowed(cap: cap) ?? true) == false
-            ) {
+            if self.filter.borrow()!.allowed(cap: cap) == false || (self.getManagerCapabilityFilter()?.allowed(cap: cap) ?? true) == false {
                 return nil
             }
 
@@ -605,7 +610,7 @@ pub contract HybridCustody {
         /// Retrieves a private Capability from the Delegator or nil none is found of the given type. Useful for
         /// arbitrary Capability retrieval
         ///
-        pub fun getPrivateCapFromDelegator(type: Type): Capability? {
+        access(Capabilities) view fun getPrivateCapFromDelegator(type: Type): Capability? {
             if let d = self.delegator.borrow() {
                 return d.getPrivateCapability(type)
             }
@@ -616,23 +621,25 @@ pub contract HybridCustody {
         /// Retrieves a public Capability from the Delegator or nil none is found of the given type. Useful for
         /// arbitrary Capability retrieval
         ///
-        pub fun getPublicCapFromDelegator(type: Type): Capability? {
+        access(all) view fun getPublicCapFromDelegator(type: Type): Capability? {
             if let d = self.delegator.borrow() {
                 return d.getPublicCapability(type)
             }
             return nil
         }
 
+        /// TODO: This has been disabled because you cannot get a capability without providing a type T anymore in Cadence 1.0
+        //
         /// Enables retrieval of public Capabilities of the given type from the specified path or nil if none is found.
         /// Callers should be aware this method uses the `CapabilityFactory` retrieval path.
         ///
-        pub fun getPublicCapability(path: PublicPath, type: Type): Capability? {
-            return self.getCapability(path: path, type: type)
-        }
+        // access(all) view fun getPublicCapability(path: PublicPath, type: Type): Capability? {
+        //     return self.getCapability(path: path, type: type)
+        // }
 
         /// Returns a reference to the stored managerCapabilityFilter if one exists
         ///
-        pub fun getManagerCapabilityFilter():  &{CapabilityFilter.Filter}? {
+        access(all) view fun getManagerCapabilityFilter(): &{CapabilityFilter.Filter}? {
             return self.managerCapabilityFilter != nil ? self.managerCapabilityFilter!.borrow() : nil
         }
 
@@ -640,23 +647,23 @@ pub contract HybridCustody {
         ///
         access(contract) fun setRedeemed(_ addr: Address) {
             let acct = self.childCap.borrow()!.borrowAccount()
-            if let o = acct.borrow<&OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) {
+            if let o = acct.storage.borrow<&OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) {
                 o.setRedeemed(addr)
             }
         }
 
         /// Returns a reference to the stored delegator, generally used for arbitrary Capability retrieval
         ///
-        pub fun borrowCapabilityDelegator(): &CapabilityDelegator.Delegator? {
+        access(Restricted) fun borrowCapabilityDelegator(): &CapabilityDelegator.Delegator? {
             let path = HybridCustody.getCapabilityDelegatorIdentifier(self.parent)
-            return self.childCap.borrow()!.borrowAccount().borrow<&CapabilityDelegator.Delegator>(
+            return self.childCap.borrow()!.borrowAccount().storage.borrow<&CapabilityDelegator.Delegator>(
                 from: StoragePath(identifier: path)!
             )
         }
 
         /// Returns a list of supported metadata views
         ///
-        pub fun getViews(): [Type] {
+        access(all) view fun getViews(): [Type] {
             return [
                 Type<MetadataViews.Display>()
             ]
@@ -664,17 +671,22 @@ pub contract HybridCustody {
 
         /// Resolves a view of the given type if supported
         ///
-        pub fun resolveView(_ view: Type): AnyStruct? {
+        access(all) fun resolveView(_ view: Type): AnyStruct? {
             switch view {
                 case Type<MetadataViews.Display>():
                     let childAddress = self.getAddress()
-                    let manager = getAccount(self.parent).getCapability<&HybridCustody.Manager{HybridCustody.ManagerPublic}>(HybridCustody.ManagerPublicPath)
+                    let tmp = getAccount(self.parent).capabilities.get<&{HybridCustody.ManagerPublic}>(HybridCustody.ManagerPublicPath)
+                    if tmp == nil {
+                        return nil
+                    }
+
+                    let manager = tmp!
 
                     if !manager.check() {
                         return nil
                     }
 
-                    return manager!.borrow()!.getChildAccountDisplay(address: childAddress)
+                    return manager.borrow()!.getChildAccountDisplay(address: childAddress)
             }
             return nil
         }
@@ -687,22 +699,22 @@ pub contract HybridCustody {
                 return
             }
 
-            let child: &AnyResource{HybridCustody.BorrowableAccount} = self.childCap.borrow()!
+            let child: &{HybridCustody.BorrowableAccount} = self.childCap.borrow()!
             if !child.check() {
                 return
             }
 
             let acct = child.borrowAccount()
-            if let ownedAcct = acct.borrow<&OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) {
+            if let ownedAcct = acct.storage.borrow<auth(Restricted) &OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) {
                 ownedAcct.removeParent(parent: parent)
             }
         }
 
         init(
-            _ childCap: Capability<&{BorrowableAccount, OwnedAccountPublic, MetadataViews.Resolver}>,
-            _ factory: Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>,
+            _ childCap: Capability<&{BorrowableAccount, OwnedAccountPublic, ViewResolver.Resolver}>,
+            _ factory: Capability<&{CapabilityFactory.Getter}>,
             _ filter: Capability<&{CapabilityFilter.Filter}>,
-            _ delegator: Capability<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPublic, CapabilityDelegator.GetterPrivate}>,
+            _ delegator: Capability<auth(Capabilities) &{CapabilityDelegator.GetterPublic, CapabilityDelegator.GetterPrivate}>,
             _ parent: Address
         ) {
             pre {
@@ -724,19 +736,20 @@ pub contract HybridCustody {
 
         /// Returns a capability to this child account's CapabilityFilter
         ///
-        pub fun getCapabilityFilter(): &{CapabilityFilter.Filter}? {
+        access(all) view fun getCapabilityFilter(): &{CapabilityFilter.Filter}? {
             return self.filter.check() ? self.filter.borrow() : nil
         }
 
         /// Returns a capability to this child account's CapabilityFactory
         ///
-        pub fun getCapabilityFactoryManager(): &{CapabilityFactory.Getter}? {
+        access(all) view fun getCapabilityFactoryManager(): &{CapabilityFactory.Getter}? {
             return self.factory.check() ? self.factory.borrow() : nil
         }
 
-        destroy () {
-            destroy <- self.resources
-        }
+        // TODO: burnCallback and ResourceDestoryed event
+        // destroy () {
+        //     destroy <- self.resources
+        // }
     }
 
     /// A resource which sits on the account it manages to make it easier for apps to configure the behavior they want 
@@ -748,18 +761,18 @@ pub contract HybridCustody {
     /// accounts would still exist, allowing a form of Hybrid Custody which has no true owner over an account, but
     /// shared partial ownership.
     ///
-    pub resource OwnedAccount: OwnedAccountPrivate, BorrowableAccount, OwnedAccountPublic, MetadataViews.Resolver {
+    access(all) resource OwnedAccount: OwnedAccountPrivate, BorrowableAccount, OwnedAccountPublic, ViewResolver.Resolver {
         /// Capability on the underlying account object
-        access(self) var acct: Capability<&AuthAccount>
+        access(self) var acct: Capability<auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account>
 
         /// Mapping of current and pending parents, true and false respectively
-        pub let parents: {Address: Bool}
+        access(all) let parents: {Address: Bool}
         /// Address of the pending owner, if one exists
-        pub var pendingOwner: Address?
+        access(all) var pendingOwner: Address?
         /// Address of the current owner, if one exists
-        pub var acctOwner: Address?
+        access(all) var acctOwner: Address?
         /// Owned status of this account
-        pub var currentlyOwned: Bool
+        access(all) var currentlyOwned: Bool
 
         /// A bucket of structs so that the OwnedAccount resource can be easily extended with new functionality.
         access(self) let data: {String: AnyStruct}
@@ -810,12 +823,12 @@ pub contract HybridCustody {
         /// 4. Publish the newly made private link to the designated parent's inbox for them to claim on their @Manager
         ///    resource.
         ///
-        pub fun publishToParent(
+        access(Restricted) fun publishToParent(
             parentAddress: Address,
-            factory: Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>,
+            factory: Capability<&{CapabilityFactory.Getter}>,
             filter: Capability<&{CapabilityFilter.Filter}>
         ) {
-            pre{
+            pre {
                 self.parents[parentAddress] == nil: "Address pending or already redeemed as parent"
             }
             let capDelegatorIdentifier = HybridCustody.getCapabilityDelegatorIdentifier(parentAddress)
@@ -826,41 +839,32 @@ pub contract HybridCustody {
             let capDelegatorStorage = StoragePath(identifier: capDelegatorIdentifier)!
             let acct = self.borrowAccount()
 
-            assert(acct.borrow<&AnyResource>(from: capDelegatorStorage) == nil, message: "conflicting resource found in capability delegator storage slot for parentAddress")
-            assert(acct.borrow<&AnyResource>(from: childAccountStorage) == nil, message: "conflicting resource found in child account storage slot for parentAddress")
+            assert(acct.storage.borrow<&AnyResource>(from: capDelegatorStorage) == nil, message: "conflicting resource found in capability delegator storage slot for parentAddress")
+            assert(acct.storage.borrow<&AnyResource>(from: childAccountStorage) == nil, message: "conflicting resource found in child account storage slot for parentAddress")
 
-            if acct.borrow<&CapabilityDelegator.Delegator>(from: capDelegatorStorage) == nil {
+            if acct.storage.borrow<&CapabilityDelegator.Delegator>(from: capDelegatorStorage) == nil {
                 let delegator <- CapabilityDelegator.createDelegator()
-                acct.save(<-delegator, to: capDelegatorStorage)
+                acct.storage.save(<-delegator, to: capDelegatorStorage)
             }
 
             let capDelegatorPublic = PublicPath(identifier: capDelegatorIdentifier)!
-            let capDelegatorPrivate = PrivatePath(identifier: capDelegatorIdentifier)!
+            // let capDelegatorPrivate = PrivatePath(identifier: capDelegatorIdentifier)!
 
-            acct.link<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPublic}>(
-                capDelegatorPublic,
-                target: capDelegatorStorage
-            )
-            acct.link<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPublic, CapabilityDelegator.GetterPrivate}>(
-                capDelegatorPrivate,
-                target: capDelegatorStorage
-            )
-            let delegator = acct.getCapability<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPublic, CapabilityDelegator.GetterPrivate}>(
-                capDelegatorPrivate
-            )
+            let pubCap = acct.capabilities.storage.issue<&{CapabilityDelegator.GetterPublic}>(capDelegatorStorage)
+            acct.capabilities.publish(pubCap, at: capDelegatorPublic)
+
+            let delegator = acct.capabilities.storage.issue<auth(Capabilities) &{CapabilityDelegator.GetterPublic, CapabilityDelegator.GetterPrivate}>(capDelegatorStorage)
             assert(delegator.check(), message: "failed to setup capability delegator for parent address")
 
-            let borrowableCap = self.borrowAccount().getCapability<&{BorrowableAccount, OwnedAccountPublic, MetadataViews.Resolver}>(
-                HybridCustody.OwnedAccountPrivatePath
+            let borrowableCap = self.borrowAccount().capabilities.storage.issue<&{BorrowableAccount, OwnedAccountPublic, ViewResolver.Resolver}>(
+                HybridCustody.OwnedAccountStoragePath
             )
-            let childAcct <- create ChildAccount(borrowableCap, factory, filter, delegator, parentAddress)
 
+            let childAcct <- create ChildAccount(borrowableCap, factory, filter, delegator, parentAddress)
             let childAccountPrivatePath = PrivatePath(identifier: identifier)!
 
-            acct.save(<-childAcct, to: childAccountStorage)
-            acct.link<&ChildAccount{AccountPrivate, AccountPublic, MetadataViews.Resolver}>(childAccountPrivatePath, target: childAccountStorage)
-            
-            let delegatorCap = acct.getCapability<&ChildAccount{AccountPrivate, AccountPublic, MetadataViews.Resolver}>(childAccountPrivatePath)
+            acct.storage.save(<-childAcct, to: childAccountStorage)            
+            let delegatorCap = acct.capabilities.storage.issue<&{AccountPrivate, AccountPublic, ViewResolver.Resolver}>(childAccountStorage)
             assert(delegatorCap.check(), message: "Delegator capability check failed")
 
             acct.inbox.publish(delegatorCap, name: identifier, recipient: parentAddress)
@@ -880,38 +884,38 @@ pub contract HybridCustody {
 
         /// Checks the validity of the encapsulated account Capability
         ///
-        pub fun check(): Bool {
+        access(all) view fun check(): Bool {
             return self.acct.check()
         }
 
         /// Returns a reference to the encapsulated account object
         ///
-        pub fun borrowAccount(): &AuthAccount {
+        access(contract) view fun borrowAccount(): auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account {
             return self.acct.borrow()!
         }
 
         /// Returns the addresses of all associated parents pending and active
         ///
-        pub fun getParentAddresses(): [Address] {
+        access(all) view fun getParentAddresses(): [Address] {
             return self.parents.keys
         }
 
         /// Returns whether the given address is a parent of this account
         ///
-        pub fun isChildOf(_ addr: Address): Bool {
+        access(all) view fun isChildOf(_ addr: Address): Bool {
             return self.parents[addr] != nil
         }
 
         /// Returns nil if the given address is not a parent, false if the parent has not redeemed the child account
         /// yet, and true if they have
         ///
-        pub fun getRedeemedStatus(addr: Address): Bool? {
+        access(all) view fun getRedeemedStatus(addr: Address): Bool? {
             return self.parents[addr]
         }
 
         /// Returns associated parent addresses and their redeemed status
         ///
-        pub fun getParentStatuses(): {Address: Bool} {
+        access(all) view fun getParentStatuses(): {Address: Bool} {
             return self.parents
         }
 
@@ -919,7 +923,7 @@ pub contract HybridCustody {
         /// configured for the provided parent address. Once done, the parent will not have any valid capabilities with
         /// which to access the child account.
         ///
-        pub fun removeParent(parent: Address): Bool {
+        access(Restricted) fun removeParent(parent: Address): Bool {
             if self.parents[parent] == nil {
                 return false
             }
@@ -927,21 +931,28 @@ pub contract HybridCustody {
             let capDelegatorIdentifier = HybridCustody.getCapabilityDelegatorIdentifier(parent)
 
             let acct = self.borrowAccount()
-            acct.unlink(PrivatePath(identifier: identifier)!)
-            acct.unlink(PublicPath(identifier: identifier)!)
 
-            acct.unlink(PrivatePath(identifier: capDelegatorIdentifier)!)
-            acct.unlink(PublicPath(identifier: capDelegatorIdentifier)!)
+            // get all controllers which target this storage path
+            let storagePath = StoragePath(identifier: identifier)!
+            let childAccountControllers = acct.capabilities.storage.getControllers(forPath: storagePath)
+            for c in childAccountControllers {
+                c.delete()
+            }
+            destroy <- acct.storage.load<@AnyResource>(from: storagePath)
 
-            destroy <- acct.load<@AnyResource>(from: StoragePath(identifier: identifier)!)
-            destroy <- acct.load<@AnyResource>(from: StoragePath(identifier: capDelegatorIdentifier)!)
+            let delegatorStoragePath = StoragePath(identifier: capDelegatorIdentifier)!
+            let delegatorControllers = acct.capabilities.storage.getControllers(forPath: delegatorStoragePath)
+            for c in delegatorControllers {
+                c.delete()
+            }
+            destroy <- acct.storage.load<@AnyResource>(from: delegatorStoragePath)
 
             self.parents.remove(key: parent)
             emit AccountUpdated(id: self.uuid, child: self.acct.address, parent: parent, active: false)
 
-            let parentManager = getAccount(parent).getCapability<&Manager{ManagerPublic}>(HybridCustody.ManagerPublicPath)
-            if parentManager.check() {
-                parentManager.borrow()?.removeParentCallback(child: self.owner!.address)
+            let parentManager = getAccount(parent).capabilities.get<&{ManagerPublic}>(HybridCustody.ManagerPublicPath)
+            if parentManager?.check() == true {
+                parentManager!.borrow()?.removeParentCallback(child: self.owner!.address)
             }
 
             return true
@@ -949,21 +960,21 @@ pub contract HybridCustody {
 
         /// Returns the address of the encapsulated account
         ///
-        pub fun getAddress(): Address {
+        access(all) view fun getAddress(): Address {
             return self.acct.address
         }
 
         /// Returns the address of the pending owner if one is assigned. Pending owners are assigned when ownership has
         /// been granted, but has not yet been redeemed.
         ///
-        pub fun getPendingOwner(): Address? {
+        access(all) view fun getPendingOwner(): Address? {
             return self.pendingOwner
         }
 
         /// Returns the address of the current owner if one is assigned. Current owners are assigned when ownership has
         /// been redeemed.
         ///
-        pub fun getOwner(): Address? {
+        access(all) view fun getOwner(): Address? {
             if !self.currentlyOwned {
                 return nil
             }
@@ -979,23 +990,19 @@ pub contract HybridCustody {
         /// mechanism intended to easily transfer 'root' access on this account to another account and an attempt to
         /// minimize access vectors.
         ///
-        pub fun giveOwnership(to: Address) {
+        access(Owner) fun giveOwnership(to: Address) {
             self.seal()
             
             let acct = self.borrowAccount()
             // Unlink existing owner's Capability if owner exists
             if self.acctOwner != nil {
-                acct.unlink(
-                    PrivatePath(identifier: HybridCustody.getOwnerIdentifier(self.acctOwner!))!
-                )
+                acct.capabilities.account.getController(byCapabilityID: self.acct.id)?.delete()
             }
+
+
             // Link a Capability for the new owner, retrieve & publish
             let identifier =  HybridCustody.getOwnerIdentifier(to)
-            let cap = acct.link<&{OwnedAccountPrivate, OwnedAccountPublic, MetadataViews.Resolver}>(
-                    PrivatePath(identifier: identifier)!,
-                    target: HybridCustody.OwnedAccountStoragePath
-                ) ?? panic("failed to link child account capability")
-
+            let cap = acct.capabilities.storage.issue<&{OwnedAccountPrivate, OwnedAccountPublic, ViewResolver.Resolver}>(HybridCustody.OwnedAccountStoragePath)
             acct.inbox.publish(cap, name: identifier, recipient: to)
 
             self.pendingOwner = to
@@ -1006,7 +1013,7 @@ pub contract HybridCustody {
 
         /// Revokes all keys on the underlying account
         ///
-        pub fun revokeAllKeys() {
+        access(Owner) fun revokeAllKeys() {
             let acct = self.borrowAccount()
 
             // Revoke all keys
@@ -1025,35 +1032,26 @@ pub contract HybridCustody {
         /// assumes ownership of an account to guarantee that the previous owner doesn't maintain admin access to the
         /// account via other AuthAccount Capabilities.
         ///
-        pub fun rotateAuthAccount() {
+        access(Owner) fun rotateAuthAccount() {
             let acct = self.borrowAccount()
 
             // Find all active AuthAccount capabilities so they can be removed after we make the new auth account cap
-            let pathsToUnlink: [PrivatePath] = []
-            acct.forEachPrivate(fun (path: PrivatePath, type: Type): Bool {
-                if type.identifier == "Capability<&AuthAccount>" {
-                    pathsToUnlink.append(path)
-                }
+            let idsToDestroy: [UInt64] = []
+            acct.capabilities.account.forEachController(fun(con: &AccountCapabilityController): Bool {
+                idsToDestroy.append(con.capabilityID)
                 return true
             })
 
             // Link a new AuthAccount Capability
-            // NOTE: This path cannot be sufficiently randomly generated, an app calling this function could build a
-            // capability to this path before it is made, thus maintaining ownership despite making it look like they
-            // gave it away. Until capability controllers, this method should not be fully trusted.
-            let authAcctPath = "HybridCustodyRelinquished_"
-                .concat(HybridCustody.account.address.toString())
-                .concat(getCurrentBlock().height.toString())
-                .concat(unsafeRandom().toString()) // ensure that the path is different from the previous one
-            let acctCap = acct.linkAccount(PrivatePath(identifier: authAcctPath)!)!
+            let acctCap = acct.capabilities.account.issue<auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account>()
 
             self.acct = acctCap
             let newAcct = self.acct.borrow()!
 
             // cleanup, remove all previously found paths. We had to do it in this order because we will be unlinking
             // the existing path which will cause a deference issue with the originally borrowed auth account
-            for  p in pathsToUnlink {
-                newAcct.unlink(p)
+            for id in idsToDestroy {
+                newAcct.capabilities.account.getController(byCapabilityID: id)?.delete()
             }
         }
 
@@ -1064,7 +1062,7 @@ pub contract HybridCustody {
         ///
         /// USE WITH EXTREME CAUTION.
         ///
-        pub fun seal() {
+        access(Owner) fun seal() {
             self.rotateAuthAccount()
             self.revokeAllKeys() // There needs to be a path to giving ownership that doesn't revoke keys   
             emit AccountSealed(id: self.uuid, address: self.acct.address, parents: self.parents.keys)
@@ -1073,16 +1071,16 @@ pub contract HybridCustody {
 
         /// Retrieves a reference to the ChildAccount associated with the given parent account if one exists.
         ///
-        pub fun borrowChildAccount(parent: Address): &ChildAccount? {
+        access(Restricted) fun borrowChildAccount(parent: Address): auth(Restricted) &ChildAccount? {
             let identifier = HybridCustody.getChildAccountIdentifier(parent)
-            return self.borrowAccount().borrow<&ChildAccount>(from: StoragePath(identifier: identifier)!)
+            return self.borrowAccount().storage.borrow<auth(Restricted) &ChildAccount>(from: StoragePath(identifier: identifier)!)
         }
 
         /// Sets the CapabilityFactory Manager for the specified parent in the associated ChildAccount.
         ///
-        pub fun setCapabilityFactoryForParent(
+        access(Restricted) fun setCapabilityFactoryForParent(
             parent: Address,
-            cap: Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>
+            cap: Capability<&{CapabilityFactory.Getter}>
         ) {
             let p = self.borrowChildAccount(parent: parent) ?? panic("could not find parent address")
             p.setCapabilityFactory(cap: cap)
@@ -1090,21 +1088,21 @@ pub contract HybridCustody {
 
         /// Sets the Filter for the specified parent in the associated ChildAccount.
         ///
-        pub fun setCapabilityFilterForParent(parent: Address, cap: Capability<&{CapabilityFilter.Filter}>) {
+        access(Restricted) fun setCapabilityFilterForParent(parent: Address, cap: Capability<&{CapabilityFilter.Filter}>) {
             let p = self.borrowChildAccount(parent: parent) ?? panic("could not find parent address")
             p.setCapabilityFilter(cap: cap)
         }
 
         /// Retrieves a reference to the Delegator associated with the given parent account if one exists.
         ///
-        pub fun borrowCapabilityDelegatorForParent(parent: Address): &CapabilityDelegator.Delegator? {
+        access(Restricted) fun borrowCapabilityDelegatorForParent(parent: Address): auth(Mutate) &CapabilityDelegator.Delegator? {
             let identifier = HybridCustody.getCapabilityDelegatorIdentifier(parent)
-            return self.borrowAccount().borrow<&CapabilityDelegator.Delegator>(from: StoragePath(identifier: identifier)!)
+            return self.borrowAccount().storage.borrow<auth(Mutate) &CapabilityDelegator.Delegator>(from: StoragePath(identifier: identifier)!)
         }
 
         /// Adds the provided Capability to the Delegator associated with the given parent account.
         ///
-        pub fun addCapabilityToDelegator(parent: Address, cap: Capability, isPublic: Bool) {
+        access(Restricted) fun addCapabilityToDelegator(parent: Address, cap: Capability, isPublic: Bool) {
             let p = self.borrowChildAccount(parent: parent) ?? panic("could not find parent address")
             let delegator = self.borrowCapabilityDelegatorForParent(parent: parent)
                 ?? panic("could not borrow capability delegator resource for parent address")
@@ -1113,20 +1111,20 @@ pub contract HybridCustody {
 
         /// Removes the provided Capability from the Delegator associated with the given parent account.
         ///
-        pub fun removeCapabilityFromDelegator(parent: Address, cap: Capability) {
+        access(Restricted) fun removeCapabilityFromDelegator(parent: Address, cap: Capability) {
             let p = self.borrowChildAccount(parent: parent) ?? panic("could not find parent address")
             let delegator = self.borrowCapabilityDelegatorForParent(parent: parent)
                 ?? panic("could not borrow capability delegator resource for parent address")
             delegator.removeCapability(cap: cap)
         }
 
-        pub fun getViews(): [Type] {
+        access(all) view fun getViews(): [Type] {
             return [
                 Type<MetadataViews.Display>()
             ]
         }
 
-        pub fun resolveView(_ view: Type): AnyStruct? {
+        access(all) fun resolveView(_ view: Type): AnyStruct? {
             switch view {
                 case Type<MetadataViews.Display>():
                     return self.display
@@ -1136,12 +1134,12 @@ pub contract HybridCustody {
 
         /// Sets this OwnedAccount's display to the one provided
         ///
-        pub fun setDisplay(_ d: MetadataViews.Display) {
+        access(Restricted) fun setDisplay(_ d: MetadataViews.Display) {
             self.display = d
         }
 
         init(
-            _ acct: Capability<&AuthAccount>
+            _ acct: Capability<auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account>
         ) {
             self.acct = acct
 
@@ -1155,36 +1153,37 @@ pub contract HybridCustody {
             self.display = nil
         }
 
-        destroy () {
-            destroy <- self.resources
-        }
+        // TODO: Use the burner interface
+        // destroy () {
+        //     destroy <- self.resources
+        // }
     }
 
     /// Utility function to get the path identifier for a parent address when interacting with a ChildAccount and its
     /// parents
     ///
-    pub fun getChildAccountIdentifier(_ addr: Address): String {
+    access(all) view fun getChildAccountIdentifier(_ addr: Address): String {
         return "ChildAccount_".concat(addr.toString())
     }
 
     /// Utility function to get the path identifier for a parent address when interacting with a Delegator and its
     /// parents
     ///
-    pub fun getCapabilityDelegatorIdentifier(_ addr: Address): String {
+    access(all) view fun getCapabilityDelegatorIdentifier(_ addr: Address): String {
         return "ChildCapabilityDelegator_".concat(addr.toString())
     }
 
     /// Utility function to get the path identifier for a parent address when interacting with an OwnedAccount and its
     /// owners
     ///
-    pub fun getOwnerIdentifier(_ addr: Address): String {
+    access(all) view fun getOwnerIdentifier(_ addr: Address): String {
         return "HybridCustodyOwnedAccount_".concat(HybridCustody.account.address.toString()).concat(addr.toString())
     }
 
     /// Returns an OwnedAccount wrapping the provided AuthAccount Capability.
     ///
-    pub fun createOwnedAccount(
-        acct: Capability<&AuthAccount>
+    access(all) fun createOwnedAccount(
+        acct: Capability<auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account>
     ): @OwnedAccount {
         pre {
             acct.check(): "invalid auth account capability"
@@ -1197,7 +1196,7 @@ pub contract HybridCustody {
 
     /// Returns a new Manager with the provided Filter as default (if not nil).
     ///
-    pub fun createManager(filter: Capability<&{CapabilityFilter.Filter}>?): @Manager {
+    access(all) fun createManager(filter: Capability<&{CapabilityFilter.Filter}>?): @Manager {
         pre {
             filter == nil || filter!.check(): "Invalid CapabilityFilter Filter capability provided"
         }

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -283,7 +283,7 @@ access(all) contract HybridCustody {
 
         /// Sets the Display on the ChildAccount. If nil, the display is removed.
         ///
-        access(Restricted) fun setChildAccountDisplay(address: Address, _ d: MetadataViews.Display?) {
+        access(Manage) fun setChildAccountDisplay(address: Address, _ d: MetadataViews.Display?) {
             pre {
                 self.childAccounts[address] != nil: "There is no child account with this address"
             }
@@ -655,9 +655,9 @@ access(all) contract HybridCustody {
 
         /// Returns a reference to the stored delegator, generally used for arbitrary Capability retrieval
         ///
-        access(Restricted) fun borrowCapabilityDelegator(): &CapabilityDelegator.Delegator? {
+        access(Owner) fun borrowCapabilityDelegator(): auth(Capabilities) &CapabilityDelegator.Delegator? {
             let path = HybridCustody.getCapabilityDelegatorIdentifier(self.parent)
-            return self.childCap.borrow()!.borrowAccount().storage.borrow<&CapabilityDelegator.Delegator>(
+            return self.childCap.borrow()!.borrowAccount().storage.borrow<auth(Capabilities) &CapabilityDelegator.Delegator>(
                 from: StoragePath(identifier: path)!
             )
         }
@@ -1072,9 +1072,9 @@ access(all) contract HybridCustody {
 
         /// Retrieves a reference to the ChildAccount associated with the given parent account if one exists.
         ///
-        access(Owner) fun borrowChildAccount(parent: Address): auth(Restricted) &ChildAccount? {
+        access(Owner) fun borrowChildAccount(parent: Address): auth(Capabilities) &ChildAccount? {
             let identifier = HybridCustody.getChildAccountIdentifier(parent)
-            return self.borrowAccount().storage.borrow<auth(Restricted) &ChildAccount>(from: StoragePath(identifier: identifier)!)
+            return self.borrowAccount().storage.borrow<auth(Capabilities) &ChildAccount>(from: StoragePath(identifier: identifier)!)
         }
 
         /// Sets the CapabilityFactory Manager for the specified parent in the associated ChildAccount.
@@ -1135,7 +1135,7 @@ access(all) contract HybridCustody {
 
         /// Sets this OwnedAccount's display to the one provided
         ///
-        access(Restricted) fun setDisplay(_ d: MetadataViews.Display) {
+        access(Owner) fun setDisplay(_ d: MetadataViews.Display) {
             self.display = d
         }
 

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -30,7 +30,6 @@ import "CapabilityFilter"
 /// Repo reference: https://github.com/onflow/hybrid-custody
 ///
 access(all) contract HybridCustody {
-
     access(all) entitlement Owner
     access(all) entitlement Child
     access(all) entitlement Publish
@@ -330,7 +329,7 @@ access(all) contract HybridCustody {
 
             self.filter = cap
         }
-        
+
         /// Sets the Filter Capability for this Manager, propagating to the specified child account
         ///
         access(Manage) fun setManagerCapabilityFilter(cap: Capability<&{CapabilityFilter.Filter}>?, childAddress: Address) {
@@ -501,6 +500,10 @@ access(all) contract HybridCustody {
             self.resources <- {}
         }
 
+        // When a manager resource is destroyed, attempt to remove this parent from every
+        // child account it currently has
+        //
+        // Destruction will fail if there are any owned account to prevent loss of access to an account
         access(contract) fun burnCallback() {
             pre {
                 // Prevent accidental burning of a resource that has ownership of other accounts
@@ -776,6 +779,7 @@ access(all) contract HybridCustody {
             return child!.getControllerIDForType(type: type, forPath: forPath)
         }
 
+        // When a ChildAccount is destroyed, attempt to remove it from the parent account as well
         access(contract) fun burnCallback() {
             self.parentRemoveChildCallback(parent: self.parent)
         }
@@ -1200,6 +1204,7 @@ access(all) contract HybridCustody {
             self.display = nil
         }
 
+        // When an OwnedAccount is destroyed, remove it from every configured parent account
         access(contract) fun burnCallback() {
             for p in self.parents.keys {
                 self.removeParent(parent: p)

--- a/contracts/factories/FTAllFactory.cdc
+++ b/contracts/factories/FTAllFactory.cdc
@@ -14,5 +14,9 @@ access(all) contract FTAllFactory {
 
             return nil
         }
+
+        access(all) view fun getPublicCapability(acct: auth(Capabilities) &Account, path: PublicPath): Capability? {
+            return nil
+        }
     }
 }

--- a/contracts/factories/FTAllFactory.cdc
+++ b/contracts/factories/FTAllFactory.cdc
@@ -1,10 +1,18 @@
 import "CapabilityFactory"
 import "FungibleToken"
 
-pub contract FTAllFactory {
-    pub struct Factory: CapabilityFactory.Factory {
-        pub fun getCapability(acct: &AuthAccount, path: CapabilityPath): Capability {
-            return acct.getCapability<&{FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance}>(path)
+access(all) contract FTAllFactory {
+    access(all) struct Factory: CapabilityFactory.Factory {
+        access(Capabilities) view fun getCapability(acct: auth(Capabilities) &Account, controllerID: UInt64): Capability? {
+            if let con = acct.capabilities.storage.getController(byCapabilityID: controllerID) {
+                if !con.capability.check<auth(FungibleToken.Withdraw) &{FungibleToken.Provider, FungibleToken.Balance, FungibleToken.Receiver}>() {
+                    return nil
+                }
+                
+                return con.capability as! Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Provider, FungibleToken.Balance, FungibleToken.Receiver}>
+            }
+
+            return nil
         }
     }
 }

--- a/contracts/factories/FTBalanceFactory.cdc
+++ b/contracts/factories/FTBalanceFactory.cdc
@@ -1,10 +1,18 @@
 import "CapabilityFactory"
 import "FungibleToken"
 
-pub contract FTBalanceFactory {
-    pub struct Factory: CapabilityFactory.Factory {
-        pub fun getCapability(acct: &AuthAccount, path: CapabilityPath): Capability {
-            return acct.getCapability<&{FungibleToken.Balance}>(path)
+access(all) contract FTBalanceFactory {
+    access(all) struct Factory: CapabilityFactory.Factory {
+        access(Capabilities) view fun getCapability(acct: auth(Capabilities) &Account, controllerID: UInt64): Capability? {
+            if let con = acct.capabilities.storage.getController(byCapabilityID: controllerID) {
+                if !con.capability.check<&{FungibleToken.Balance}>() {
+                    return nil
+                }
+
+                return con.capability as! Capability<&{FungibleToken.Balance}>
+            }
+
+            return nil
         }
     }
 }

--- a/contracts/factories/FTBalanceFactory.cdc
+++ b/contracts/factories/FTBalanceFactory.cdc
@@ -14,5 +14,9 @@ access(all) contract FTBalanceFactory {
 
             return nil
         }
+
+        access(all) view fun getPublicCapability(acct: auth(Capabilities) &Account, path: PublicPath): Capability? {
+            return acct.capabilities.get<&{FungibleToken.Balance}>(path)
+        }
     }
 }

--- a/contracts/factories/FTProviderFactory.cdc
+++ b/contracts/factories/FTProviderFactory.cdc
@@ -9,7 +9,7 @@ access(all) contract FTProviderFactory {
                     return nil
                 }
 
-                return con.capability as! Capability<&auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>
+                return con.capability as! Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>
             }
 
             return nil

--- a/contracts/factories/FTProviderFactory.cdc
+++ b/contracts/factories/FTProviderFactory.cdc
@@ -14,5 +14,9 @@ access(all) contract FTProviderFactory {
 
             return nil
         }
+
+        access(all) view fun getPublicCapability(acct: auth(Capabilities) &Account, path: PublicPath): Capability? {
+            return nil
+        }
     }
 }

--- a/contracts/factories/FTProviderFactory.cdc
+++ b/contracts/factories/FTProviderFactory.cdc
@@ -1,10 +1,18 @@
 import "CapabilityFactory"
 import "FungibleToken"
 
-pub contract FTProviderFactory {
-    pub struct Factory: CapabilityFactory.Factory {
-        pub fun getCapability(acct: &AuthAccount, path: CapabilityPath): Capability {
-            return acct.getCapability<&{FungibleToken.Provider}>(path)
+access(all) contract FTProviderFactory {
+    access(all) struct Factory: CapabilityFactory.Factory {
+        access(Capabilities) view fun getCapability(acct: auth(Capabilities) &Account, controllerID: UInt64): Capability? {
+            if let con = acct.capabilities.storage.getController(byCapabilityID: controllerID) {
+                if !con.capability.check<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>() {
+                    return nil
+                }
+
+                return con.capability as! Capability<&auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>
+            }
+
+            return nil
         }
     }
 }

--- a/contracts/factories/FTReceiverBalanceFactory.cdc
+++ b/contracts/factories/FTReceiverBalanceFactory.cdc
@@ -14,5 +14,9 @@ access(all) contract FTReceiverBalanceFactory {
 
             return nil
         }
+
+        access(all) view fun getPublicCapability(acct: auth(Capabilities) &Account, path: PublicPath): Capability? {
+            return acct.capabilities.get<&{FungibleToken.Receiver, FungibleToken.Balance}>(path)
+        }
     }
 }

--- a/contracts/factories/FTReceiverBalanceFactory.cdc
+++ b/contracts/factories/FTReceiverBalanceFactory.cdc
@@ -1,10 +1,18 @@
 import "CapabilityFactory"
 import "FungibleToken"
 
-pub contract FTReceiverBalanceFactory {
-    pub struct Factory: CapabilityFactory.Factory {
-        pub fun getCapability(acct: &AuthAccount, path: CapabilityPath): Capability {
-            return acct.getCapability<&{FungibleToken.Receiver, FungibleToken.Balance}>(path)
+access(all) contract FTReceiverBalanceFactory {
+    access(all) struct Factory: CapabilityFactory.Factory {
+        access(Capabilities) view fun getCapability(acct: auth(Capabilities) &Account, controllerID: UInt64): Capability? {
+            if let con = acct.capabilities.storage.getController(byCapabilityID: controllerID) {
+                if !con.capability.check<&{FungibleToken.Receiver, FungibleToken.Balance}>() {
+                    return nil
+                }
+
+                return con.capability as! Capability<&{FungibleToken.Receiver, FungibleToken.Balance}>
+            }
+
+            return nil
         }
     }
 }

--- a/contracts/factories/FTReceiverFactory.cdc
+++ b/contracts/factories/FTReceiverFactory.cdc
@@ -14,5 +14,9 @@ access(all) contract FTReceiverFactory {
 
             return nil
         }
+
+        access(all) view fun getPublicCapability(acct: auth(Capabilities) &Account, path: PublicPath): Capability? {
+            return acct.capabilities.get<&{FungibleToken.Receiver}>(path)
+        }
     }
 }

--- a/contracts/factories/FTReceiverFactory.cdc
+++ b/contracts/factories/FTReceiverFactory.cdc
@@ -1,10 +1,18 @@
 import "CapabilityFactory"
 import "FungibleToken"
 
-pub contract FTReceiverFactory {
-    pub struct Factory: CapabilityFactory.Factory {
-        pub fun getCapability(acct: &AuthAccount, path: CapabilityPath): Capability {
-            return acct.getCapability<&{FungibleToken.Receiver}>(path)
+access(all) contract FTReceiverFactory {
+    access(all) struct Factory: CapabilityFactory.Factory {
+        access(Capabilities) view fun getCapability(acct: auth(Capabilities) &Account, controllerID: UInt64): Capability? {
+            if let con = acct.capabilities.storage.getController(byCapabilityID: controllerID) {
+                if !con.capability.check<&{FungibleToken.Receiver}>() {
+                    return nil
+                }
+
+                return con.capability as! Capability<&{FungibleToken.Receiver}>
+            }
+
+            return nil
         }
     }
 }

--- a/contracts/factories/NFTCollectionPublicFactory.cdc
+++ b/contracts/factories/NFTCollectionPublicFactory.cdc
@@ -1,10 +1,18 @@
 import "CapabilityFactory"
 import "NonFungibleToken"
 
-pub contract NFTCollectionPublicFactory {
-    pub struct Factory: CapabilityFactory.Factory {
-        pub fun getCapability(acct: &AuthAccount, path: CapabilityPath): Capability {
-            return acct.getCapability<&{NonFungibleToken.CollectionPublic}>(path)
+access(all) contract NFTCollectionPublicFactory {
+    access(all) struct Factory: CapabilityFactory.Factory {
+        access(Capabilities) view fun getCapability(acct: auth(Capabilities) &Account, controllerID: UInt64): Capability? {
+            if let con = acct.capabilities.storage.getController(byCapabilityID: controllerID) {
+                if !con.capability.check<&{NonFungibleToken.CollectionPublic}>() {
+                    return nil
+                }
+
+                return con.capability as! Capability<&{NonFungibleToken.CollectionPublic}>
+            }
+
+            return nil
         }
     }
 }

--- a/contracts/factories/NFTCollectionPublicFactory.cdc
+++ b/contracts/factories/NFTCollectionPublicFactory.cdc
@@ -14,5 +14,9 @@ access(all) contract NFTCollectionPublicFactory {
 
             return nil
         }
+
+        access(all) view fun getPublicCapability(acct: auth(Capabilities) &Account, path: PublicPath): Capability? {
+            return acct.capabilities.get<&{NonFungibleToken.CollectionPublic}>(path)
+        }
     }
 }

--- a/contracts/factories/NFTProviderAndCollectionFactory.cdc
+++ b/contracts/factories/NFTProviderAndCollectionFactory.cdc
@@ -1,10 +1,18 @@
 import "CapabilityFactory"
 import "NonFungibleToken"
 
-pub contract NFTProviderAndCollectionFactory {
-    pub struct Factory: CapabilityFactory.Factory {
-        pub fun getCapability(acct: &AuthAccount, path: CapabilityPath): Capability {
-            return acct.getCapability<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(path)
+access(all) contract NFTProviderAndCollectionFactory {
+    access(all) struct Factory: CapabilityFactory.Factory {
+        access(Capabilities) view fun getCapability(acct: auth(Capabilities) &Account, controllerID: UInt64): Capability? {
+            if let con = acct.capabilities.storage.getController(byCapabilityID: controllerID) {
+                if !con.capability.check<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>() {
+                    return nil
+                }
+
+                return con.capability as! Capability<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>
+            }
+
+            return nil
         }
     }
 }

--- a/contracts/factories/NFTProviderAndCollectionFactory.cdc
+++ b/contracts/factories/NFTProviderAndCollectionFactory.cdc
@@ -14,5 +14,9 @@ access(all) contract NFTProviderAndCollectionFactory {
 
             return nil
         }
+
+        access(all) view fun getPublicCapability(acct: auth(Capabilities) &Account, path: PublicPath): Capability? {
+            return nil
+        }
     }
 }

--- a/contracts/factories/NFTProviderFactory.cdc
+++ b/contracts/factories/NFTProviderFactory.cdc
@@ -14,5 +14,9 @@ access(all) contract NFTProviderFactory {
 
             return nil
         }
+
+        access(all) view fun getPublicCapability(acct: auth(Capabilities) &Account, path: PublicPath): Capability? {
+            return nil
+        }
     }
 }

--- a/contracts/factories/NFTProviderFactory.cdc
+++ b/contracts/factories/NFTProviderFactory.cdc
@@ -1,10 +1,18 @@
 import "CapabilityFactory"
 import "NonFungibleToken"
 
-pub contract NFTProviderFactory {
-    pub struct Factory: CapabilityFactory.Factory {
-        pub fun getCapability(acct: &AuthAccount, path: CapabilityPath): Capability {
-            return acct.getCapability<&{NonFungibleToken.Provider}>(path)
+access(all) contract NFTProviderFactory {
+    access(all) struct Factory: CapabilityFactory.Factory {
+        access(Capabilities) view fun getCapability(acct: auth(Capabilities) &Account, controllerID: UInt64): Capability? {
+            if let con = acct.capabilities.storage.getController(byCapabilityID: controllerID) {
+                if !con.capability.check<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>() {
+                    return nil
+                }
+
+                return con.capability as! Capability<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>
+            }
+
+            return nil
         }
     }
 }

--- a/contracts/standard/ExampleNFT.cdc
+++ b/contracts/standard/ExampleNFT.cdc
@@ -1,0 +1,376 @@
+/* 
+*
+*  This is an example implementation of a Flow Non-Fungible Token
+*  It is not part of the official standard but it assumed to be
+*  similar to how many NFTs would implement the core functionality.
+*
+*  This contract does not implement any sophisticated classification
+*  system for its NFTs. It defines a simple NFT with minimal metadata.
+*   
+*/
+
+import "NonFungibleToken"
+import "MetadataViews"
+import "ViewResolver"
+import "FungibleToken"
+
+access(all) contract ExampleNFT: ViewResolver {
+
+    access(all) var totalSupply: UInt64
+
+    access(all) event ContractInitialized()
+    access(all) event Withdraw(id: UInt64, from: Address?)
+    access(all) event Deposit(id: UInt64, to: Address?)
+
+    access(all) event CollectionCreated(id: UInt64)
+    access(all) event CollectionDestroyed(id: UInt64)
+
+    access(all) let CollectionStoragePath: StoragePath
+    access(all) let CollectionPublicPath: PublicPath
+    access(all) let MinterStoragePath: StoragePath
+    access(all) let MinterPublicPath: PublicPath
+
+    access(all) resource NFT: NonFungibleToken.NFT, ViewResolver.Resolver {
+        access(all) let id: UInt64
+
+        access(all) let name: String
+        access(all) let description: String
+        access(all) let thumbnail: String
+        access(self) let royalties: [MetadataViews.Royalty]
+
+        init(
+            id: UInt64,
+            name: String,
+            description: String,
+            thumbnail: String,
+            royalties: [MetadataViews.Royalty]
+        ) {
+            self.id = id
+            self.name = name
+            self.description = description
+            self.thumbnail = thumbnail
+            self.royalties = royalties
+        }
+    
+        access(all) view fun getViews(): [Type] {
+            return [
+                Type<MetadataViews.Display>(),
+                Type<MetadataViews.Royalties>(),
+                Type<MetadataViews.Editions>(),
+                Type<MetadataViews.ExternalURL>(),
+                Type<MetadataViews.NFTCollectionData>(),
+                Type<MetadataViews.NFTCollectionDisplay>(),
+                Type<MetadataViews.Serial>()
+            ]
+        }
+
+        access(all) view fun resolveView(_ view: Type): AnyStruct? {
+            switch view {
+                case Type<MetadataViews.Display>():
+                    return MetadataViews.Display(
+                        name: self.name,
+                        description: self.description,
+                        thumbnail: MetadataViews.HTTPFile(
+                            url: self.thumbnail
+                        )
+                    )
+                case Type<MetadataViews.Editions>():
+                    // There is no max number of NFTs that can be minted from this contract
+                    // so the max edition field value is set to nil
+                    let editionInfo = MetadataViews.Edition(name: "Example NFT Edition", number: self.id, max: nil)
+                    let editionList: [MetadataViews.Edition] = [editionInfo]
+                    return MetadataViews.Editions(
+                        editionList
+                    )
+                case Type<MetadataViews.Serial>():
+                    return MetadataViews.Serial(
+                        self.id
+                    )
+                case Type<MetadataViews.Royalties>():
+                    return MetadataViews.Royalties(
+                        self.royalties
+                    )
+                case Type<MetadataViews.ExternalURL>():
+                    return MetadataViews.ExternalURL("https://example-nft.onflow.org/".concat(self.id.toString()))
+                case Type<MetadataViews.NFTCollectionData>():
+                    return MetadataViews.NFTCollectionData(
+                        storagePath: ExampleNFT.CollectionStoragePath,
+                        publicPath: ExampleNFT.CollectionPublicPath,
+                        publicCollection: Type<&ExampleNFT.Collection>(),
+                        publicLinkedType: Type<&ExampleNFT.Collection>(),
+                        createEmptyCollectionFunction: (fun (): @{NonFungibleToken.Collection} {
+                            return <-ExampleNFT.createEmptyCollection()
+                        })
+                    )
+                case Type<MetadataViews.NFTCollectionDisplay>():
+                    let media = MetadataViews.Media(
+                        file: MetadataViews.HTTPFile(
+                            url: "https://assets.website-files.com/5f6294c0c7a8cdd643b1c820/5f6294c0c7a8cda55cb1c936_Flow_Wordmark.svg"
+                        ),
+                        mediaType: "image/svg+xml"
+                    )
+                    return MetadataViews.NFTCollectionDisplay(
+                        name: "The Example Collection",
+                        description: "This collection is used as an example to help you develop your next Flow NFT.",
+                        externalURL: MetadataViews.ExternalURL("https://example-nft.onflow.org"),
+                        squareImage: media,
+                        bannerImage: media,
+                        socials: {
+                            "twitter": MetadataViews.ExternalURL("https://twitter.com/flow_blockchain")
+                        }
+                    )
+            }
+            return nil
+        }
+
+        access(all) fun createEmptyCollection(): @{NonFungibleToken.Collection} {
+            return <- ExampleNFT.createEmptyCollection()
+        }
+    }
+
+    access(all) resource interface ExampleNFTCollectionPublic: NonFungibleToken.Collection {
+        access(all) fun deposit(token: @{NonFungibleToken.NFT})
+        access(all) fun borrowExampleNFT(id: UInt64): &ExampleNFT.NFT? {
+            post {
+                (result == nil) || (result?.id == id):
+                    "Cannot borrow ExampleNFT reference: the ID of the returned reference is incorrect"
+            }
+        }
+    }
+
+    access(all) resource Collection: ExampleNFTCollectionPublic {
+        access(all) event ResourceDestroyed(id: UInt64 = self.uuid)
+
+        // dictionary of NFT conforming tokens
+        // NFT is a resource type with an `UInt64` ID field
+        access(all) var ownedNFTs: @{UInt64: {NonFungibleToken.NFT}}
+
+        init () {
+            self.ownedNFTs <- {}
+            emit CollectionCreated(id: self.uuid)
+        }
+
+        access(all) view fun getLength(): Int {
+            return self.ownedNFTs.length
+        }
+
+        // withdraw removes an NFT from the collection and moves it to the caller
+        access(NonFungibleToken.Withdraw | NonFungibleToken.Owner) fun withdraw(withdrawID: UInt64): @{NonFungibleToken.NFT} {
+            let token <- self.ownedNFTs.remove(key: withdrawID) ?? panic("missing NFT")
+
+            emit Withdraw(id: token.id, from: self.owner?.address)
+
+            return <-token
+        }
+
+        // deposit takes a NFT and adds it to the collections dictionary
+        // and adds the ID to the id array
+        access(all) fun deposit(token: @{NonFungibleToken.NFT}) {
+            let token <- token as! @ExampleNFT.NFT
+
+            let id: UInt64 = token.id
+
+            // add the new token to the dictionary which removes the old one
+            let oldToken <- self.ownedNFTs[id] <- token
+
+            emit Deposit(id: id, to: self.owner?.address)
+
+            destroy oldToken
+        }
+
+        // getIDs returns an array of the IDs that are in the collection
+        access(all) view fun getIDs(): [UInt64] {
+            return self.ownedNFTs.keys
+        }
+
+        // borrowNFT gets a reference to an NFT in the collection
+        // so that the caller can read its metadata and call its methods
+        access(all) view fun borrowNFT(_ id: UInt64): &{NonFungibleToken.NFT}? {
+            return (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)!
+        }
+ 
+        access(all) fun borrowExampleNFT(id: UInt64): &ExampleNFT.NFT? {
+            if self.ownedNFTs[id] != nil {
+                // Create an authorized reference to allow downcasting
+                let ref = (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)!
+                return ref as! &ExampleNFT.NFT
+            }
+
+            return nil
+        }
+
+        access(all) fun createEmptyCollection(): @{NonFungibleToken.Collection} {
+            return <- create Collection()
+        }
+
+        access(all) view fun getSupportedNFTTypes(): {Type: Bool} {
+            return {
+                Type<@ExampleNFT.NFT>(): true
+            }
+        }
+
+        access(all) view fun isSupportedNFTType(type: Type): Bool {
+            return type == Type<@ExampleNFT.NFT>()
+        }
+    }
+
+    // public function that anyone can call to create a new empty collection
+    access(all) fun createEmptyCollection(): @{NonFungibleToken.Collection} {
+        return <- create Collection()
+    }
+
+    // Resource that an admin or something similar would own to be
+    // able to mint new NFTs
+    //
+    access(all) resource NFTMinter {
+
+        // mintNFT mints a new NFT with a new ID
+        // and deposit it in the recipients collection using their collection reference
+        access(all) fun mintNFT(
+            recipient: &{NonFungibleToken.CollectionPublic},
+            name: String,
+            description: String,
+            thumbnail: String,
+            royaltyReceipient: Address,
+        ) {
+            ExampleNFT.totalSupply = ExampleNFT.totalSupply + 1
+            self.mintNFTWithId(recipient: recipient, name: name, description: description, thumbnail: thumbnail, royaltyReceipient: royaltyReceipient, id: ExampleNFT.totalSupply)
+        }
+
+        access(all) fun mintNFTWithId(
+            recipient: &{NonFungibleToken.CollectionPublic},
+            name: String,
+            description: String,
+            thumbnail: String,
+            royaltyReceipient: Address,
+            id: UInt64
+        ) {
+            let royaltyRecipient = getAccount(royaltyReceipient).capabilities.get<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)!
+            let cutInfo = MetadataViews.Royalty(receiver: royaltyRecipient, cut: 0.05, description: "")
+            // create a new NFT
+            var newNFT <- create NFT(
+                id: id,
+                name: name,
+                description: description,
+                thumbnail: thumbnail,
+                royalties: [cutInfo]
+            )
+
+            // deposit it in the recipient's account using their reference
+            recipient.deposit(token: <-newNFT)
+        }
+
+        // mintNFT mints a new NFT with a new ID
+        // and deposit it in the recipients collection using their collection reference
+        access(all) fun mintNFTWithRoyaltyCuts(
+            recipient: &{NonFungibleToken.CollectionPublic},
+            name: String,
+            description: String,
+            thumbnail: String,
+            royaltyReceipients: [Address],
+            royaltyCuts: [UFix64]
+        ) {
+            assert(royaltyReceipients.length == royaltyCuts.length, message: "mismatched royalty recipients and cuts")
+            let royalties: [MetadataViews.Royalty] = []
+
+            var index = 0
+            while index < royaltyReceipients.length {
+                let royaltyRecipient = getAccount(royaltyReceipients[index]).capabilities.get<&{FungibleToken.Receiver}>(/public/placeholder)!
+                let cutInfo = MetadataViews.Royalty(receiver: royaltyRecipient, cut: royaltyCuts[index], description: "")
+                royalties.append(cutInfo)
+                index = index + 1
+            }            
+
+            ExampleNFT.totalSupply = ExampleNFT.totalSupply + 1
+
+            // create a new NFT
+            var newNFT <- create NFT(
+                id: ExampleNFT.totalSupply,
+                name: name,
+                description: description,
+                thumbnail: thumbnail,
+                royalties: royalties
+            )
+
+            // deposit it in the recipient's account using their reference
+            recipient.deposit(token: <-newNFT)
+        }
+    }
+
+    /// Function that resolves a metadata view for this contract.
+    ///
+    /// @param view: The Type of the desired view.
+    /// @return A structure representing the requested view.
+    ///
+    access(all) fun resolveContractView(resourceType: Type?, viewType: Type): AnyStruct? {
+        switch viewType {
+            case Type<MetadataViews.NFTCollectionData>():
+                return MetadataViews.NFTCollectionData(
+                        storagePath: ExampleNFT.CollectionStoragePath,
+                        publicPath: ExampleNFT.CollectionPublicPath,
+                        publicCollection: Type<&ExampleNFT.Collection>(),
+                        publicLinkedType: Type<&ExampleNFT.Collection>(),
+                        createEmptyCollectionFunction: (fun (): @{NonFungibleToken.Collection} {
+                            return <-ExampleNFT.createEmptyCollection()
+                        })
+                )
+            case Type<MetadataViews.NFTCollectionDisplay>():
+                let media = MetadataViews.Media(
+                    file: MetadataViews.HTTPFile(
+                        url: "https://assets.website-files.com/5f6294c0c7a8cdd643b1c820/5f6294c0c7a8cda55cb1c936_Flow_Wordmark.svg"
+                    ),
+                    mediaType: "image/svg+xml"
+                )
+                return MetadataViews.NFTCollectionDisplay(
+                    name: "The Example Collection",
+                    description: "This collection is used as an example to help you develop your next Flow NFT.",
+                    externalURL: MetadataViews.ExternalURL("https://example-nft.onflow.org"),
+                    squareImage: media,
+                    bannerImage: media,
+                    socials: {
+                        "twitter": MetadataViews.ExternalURL("https://twitter.com/flow_blockchain")
+                    }
+                )
+        }
+        return nil
+    }
+
+    /// Function that returns all the Metadata Views implemented by a Non Fungible Token
+    ///
+    /// @return An array of Types defining the implemented views. This value will be used by
+    ///         developers to know which parameter to pass to the resolveView() method.
+    ///
+    access(all) view fun getContractViews(resourceType: Type?): [Type] {
+        return [
+            Type<MetadataViews.NFTCollectionData>(),
+            Type<MetadataViews.NFTCollectionDisplay>()
+        ]
+    }
+
+    init() {
+        // Initialize the total supply
+        self.totalSupply = 0
+
+        // Set the named paths
+        self.CollectionStoragePath = /storage/exampleNFTCollection
+        self.CollectionPublicPath = /public/exampleNFTCollection
+        self.MinterStoragePath = /storage/exampleNFTMinter
+        self.MinterPublicPath = /public/exampleNFTMinter
+
+        // Create a Collection resource and save it to storage
+        let collection <- create Collection()
+        self.account.storage.save(<-collection, to: self.CollectionStoragePath)
+        let cap = self.account.capabilities.storage.issue<&ExampleNFT.Collection>(self.CollectionStoragePath)
+        self.account.capabilities.publish(cap, at: self.CollectionPublicPath)
+
+
+        // Create a Minter resource and save it to storage
+        let minter <- create NFTMinter()
+        self.account.storage.save(<-minter, to: self.MinterStoragePath)
+
+        let minterCap = self.account.capabilities.storage.issue<&ExampleNFT.NFTMinter>(self.MinterStoragePath)
+
+        emit ContractInitialized()
+    }
+}
+ 

--- a/contracts/standard/ExampleNFT2.cdc
+++ b/contracts/standard/ExampleNFT2.cdc
@@ -12,64 +12,47 @@
 import "NonFungibleToken"
 import "MetadataViews"
 import "ViewResolver"
+import "FungibleToken"
 
-pub contract ExampleNFT2: NonFungibleToken, ViewResolver {
+access(all) contract ExampleNFT2: ViewResolver {
 
-    /// Total supply of ExampleNFTs in existence
-    pub var totalSupply: UInt64
+    access(all) var totalSupply: UInt64
 
-    /// The event that is emitted when the contract is created
-    pub event ContractInitialized()
+    access(all) event ContractInitialized()
+    access(all) event Withdraw(id: UInt64, from: Address?)
+    access(all) event Deposit(id: UInt64, to: Address?)
 
-    /// The event that is emitted when an NFT is withdrawn from a Collection
-    pub event Withdraw(id: UInt64, from: Address?)
+    access(all) event CollectionCreated(id: UInt64)
+    access(all) event CollectionDestroyed(id: UInt64)
 
-    /// The event that is emitted when an NFT is deposited to a Collection
-    pub event Deposit(id: UInt64, to: Address?)
+    access(all) let CollectionStoragePath: StoragePath
+    access(all) let CollectionPublicPath: PublicPath
+    access(all) let MinterStoragePath: StoragePath
+    access(all) let MinterPublicPath: PublicPath
 
-    /// Storage and Public Paths
-    pub let CollectionStoragePath: StoragePath
-    pub let CollectionPublicPath: PublicPath
-    pub let MinterStoragePath: StoragePath
+    access(all) resource NFT: NonFungibleToken.NFT, ViewResolver.Resolver {
+        access(all) let id: UInt64
 
-    /// The core resource that represents a Non Fungible Token. 
-    /// New instances will be created using the NFTMinter resource
-    /// and stored in the Collection resource
-    ///
-    pub resource NFT: NonFungibleToken.INFT, MetadataViews.Resolver {
-        
-        /// The unique ID that each NFT has
-        pub let id: UInt64
-
-        /// Metadata fields
-        pub let name: String
-        pub let description: String
-        pub let thumbnail: String
+        access(all) let name: String
+        access(all) let description: String
+        access(all) let thumbnail: String
         access(self) let royalties: [MetadataViews.Royalty]
-        access(self) let metadata: {String: AnyStruct}
-    
+
         init(
             id: UInt64,
             name: String,
             description: String,
             thumbnail: String,
-            royalties: [MetadataViews.Royalty],
-            metadata: {String: AnyStruct},
+            royalties: [MetadataViews.Royalty]
         ) {
             self.id = id
             self.name = name
             self.description = description
             self.thumbnail = thumbnail
             self.royalties = royalties
-            self.metadata = metadata
         }
-
-        /// Function that returns all the Metadata Views implemented by a Non Fungible Token
-        ///
-        /// @return An array of Types defining the implemented views. This value will be used by
-        ///         developers to know which parameter to pass to the resolveView() method.
-        ///
-        pub fun getViews(): [Type] {
+    
+        access(all) view fun getViews(): [Type] {
             return [
                 Type<MetadataViews.Display>(),
                 Type<MetadataViews.Royalties>(),
@@ -77,17 +60,11 @@ pub contract ExampleNFT2: NonFungibleToken, ViewResolver {
                 Type<MetadataViews.ExternalURL>(),
                 Type<MetadataViews.NFTCollectionData>(),
                 Type<MetadataViews.NFTCollectionDisplay>(),
-                Type<MetadataViews.Serial>(),
-                Type<MetadataViews.Traits>()
+                Type<MetadataViews.Serial>()
             ]
         }
 
-        /// Function that resolves a metadata view for this token.
-        ///
-        /// @param view: The Type of the desired view.
-        /// @return A structure representing the requested view.
-        ///
-        pub fun resolveView(_ view: Type): AnyStruct? {
+        access(all) view fun resolveView(_ view: Type): AnyStruct? {
             switch view {
                 case Type<MetadataViews.Display>():
                     return MetadataViews.Display(
@@ -119,11 +96,9 @@ pub contract ExampleNFT2: NonFungibleToken, ViewResolver {
                     return MetadataViews.NFTCollectionData(
                         storagePath: ExampleNFT2.CollectionStoragePath,
                         publicPath: ExampleNFT2.CollectionPublicPath,
-                        providerPath: /private/exampleNFT2Collection,
-                        publicCollection: Type<&ExampleNFT2.Collection{ExampleNFT2.ExampleNFT2CollectionPublic}>(),
-                        publicLinkedType: Type<&ExampleNFT2.Collection{ExampleNFT2.ExampleNFT2CollectionPublic,NonFungibleToken.CollectionPublic,NonFungibleToken.Receiver,MetadataViews.ResolverCollection}>(),
-                        providerLinkedType: Type<&ExampleNFT2.Collection{ExampleNFT2.ExampleNFT2CollectionPublic,NonFungibleToken.CollectionPublic,NonFungibleToken.Provider,MetadataViews.ResolverCollection}>(),
-                        createEmptyCollectionFunction: (fun (): @NonFungibleToken.Collection {
+                        publicCollection: Type<&ExampleNFT2.Collection>(),
+                        publicLinkedType: Type<&ExampleNFT2.Collection>(),
+                        createEmptyCollectionFunction: (fun (): @{NonFungibleToken.Collection} {
                             return <-ExampleNFT2.createEmptyCollection()
                         })
                     )
@@ -144,34 +119,18 @@ pub contract ExampleNFT2: NonFungibleToken, ViewResolver {
                             "twitter": MetadataViews.ExternalURL("https://twitter.com/flow_blockchain")
                         }
                     )
-                case Type<MetadataViews.Traits>():
-                    // exclude mintedTime and foo to show other uses of Traits
-                    let excludedTraits = ["mintedTime", "foo"]
-                    let traitsView = MetadataViews.dictToTraits(dict: self.metadata, excludedNames: excludedTraits)
-
-                    // mintedTime is a unix timestamp, we should mark it with a displayType so platforms know how to show it.
-                    let mintedTimeTrait = MetadataViews.Trait(name: "mintedTime", value: self.metadata["mintedTime"]!, displayType: "Date", rarity: nil)
-                    traitsView.addTrait(mintedTimeTrait)
-
-                    // foo is a trait with its own rarity
-                    let fooTraitRarity = MetadataViews.Rarity(score: 10.0, max: 100.0, description: "Common")
-                    let fooTrait = MetadataViews.Trait(name: "foo", value: self.metadata["foo"], displayType: nil, rarity: fooTraitRarity)
-                    traitsView.addTrait(fooTrait)
-                    
-                    return traitsView
-
             }
             return nil
         }
+
+        access(all) fun createEmptyCollection(): @{NonFungibleToken.Collection} {
+            return <- ExampleNFT2.createEmptyCollection()
+        }
     }
 
-    /// Defines the methods that are particular to this NFT contract collection
-    ///
-    pub resource interface ExampleNFT2CollectionPublic {
-        pub fun deposit(token: @NonFungibleToken.NFT)
-        pub fun getIDs(): [UInt64]
-        pub fun borrowNFT(id: UInt64): &NonFungibleToken.NFT
-        pub fun borrowExampleNFT(id: UInt64): &ExampleNFT2.NFT? {
+    access(all) resource interface ExampleNFT2CollectionPublic: NonFungibleToken.Collection {
+        access(all) fun deposit(token: @{NonFungibleToken.NFT})
+        access(all) fun borrowExampleNFT2(id: UInt64): &ExampleNFT2.NFT? {
             post {
                 (result == nil) || (result?.id == id):
                     "Cannot borrow ExampleNFT2 reference: the ID of the returned reference is incorrect"
@@ -179,25 +138,24 @@ pub contract ExampleNFT2: NonFungibleToken, ViewResolver {
         }
     }
 
-    /// The resource that will be holding the NFTs inside any account.
-    /// In order to be able to manage NFTs any account will need to create
-    /// an empty collection first
-    ///
-    pub resource Collection: ExampleNFT2CollectionPublic, NonFungibleToken.Provider, NonFungibleToken.Receiver, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection {
+    access(all) resource Collection: ExampleNFT2CollectionPublic {
+        access(all) event ResourceDestroyed(id: UInt64 = self.uuid)
+
         // dictionary of NFT conforming tokens
         // NFT is a resource type with an `UInt64` ID field
-        pub var ownedNFTs: @{UInt64: NonFungibleToken.NFT}
+        access(all) var ownedNFTs: @{UInt64: {NonFungibleToken.NFT}}
 
         init () {
             self.ownedNFTs <- {}
+            emit CollectionCreated(id: self.uuid)
         }
 
-        /// Removes an NFT from the collection and moves it to the caller
-        ///
-        /// @param withdrawID: The ID of the NFT that wants to be withdrawn
-        /// @return The NFT resource that has been taken out of the collection
-        ///
-        pub fun withdraw(withdrawID: UInt64): @NonFungibleToken.NFT {
+        access(all) view fun getLength(): Int {
+            return self.ownedNFTs.length
+        }
+
+        // withdraw removes an NFT from the collection and moves it to the caller
+        access(NonFungibleToken.Withdraw | NonFungibleToken.Owner) fun withdraw(withdrawID: UInt64): @{NonFungibleToken.NFT} {
             let token <- self.ownedNFTs.remove(key: withdrawID) ?? panic("missing NFT")
 
             emit Withdraw(id: token.id, from: self.owner?.address)
@@ -205,11 +163,9 @@ pub contract ExampleNFT2: NonFungibleToken, ViewResolver {
             return <-token
         }
 
-        /// Adds an NFT to the collections dictionary and adds the ID to the id array
-        ///
-        /// @param token: The NFT resource to be included in the collection
-        /// 
-        pub fun deposit(token: @NonFungibleToken.NFT) {
+        // deposit takes a NFT and adds it to the collections dictionary
+        // and adds the ID to the id array
+        access(all) fun deposit(token: @{NonFungibleToken.NFT}) {
             let token <- token as! @ExampleNFT2.NFT
 
             let id: UInt64 = token.id
@@ -222,95 +178,110 @@ pub contract ExampleNFT2: NonFungibleToken, ViewResolver {
             destroy oldToken
         }
 
-        /// Helper method for getting the collection IDs
-        ///
-        /// @return An array containing the IDs of the NFTs in the collection
-        ///
-        pub fun getIDs(): [UInt64] {
+        // getIDs returns an array of the IDs that are in the collection
+        access(all) view fun getIDs(): [UInt64] {
             return self.ownedNFTs.keys
         }
 
-        /// Gets a reference to an NFT in the collection so that 
-        /// the caller can read its metadata and call its methods
-        ///
-        /// @param id: The ID of the wanted NFT
-        /// @return A reference to the wanted NFT resource
-        ///
-        pub fun borrowNFT(id: UInt64): &NonFungibleToken.NFT {
-            return (&self.ownedNFTs[id] as &NonFungibleToken.NFT?)!
+        // borrowNFT gets a reference to an NFT in the collection
+        // so that the caller can read its metadata and call its methods
+        access(all) view fun borrowNFT(_ id: UInt64): &{NonFungibleToken.NFT}? {
+            return (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)!
         }
  
-        /// Gets a reference to an NFT in the collection so that 
-        /// the caller can read its metadata and call its methods
-        ///
-        /// @param id: The ID of the wanted NFT
-        /// @return A reference to the wanted NFT resource
-        ///        
-        pub fun borrowExampleNFT(id: UInt64): &ExampleNFT2.NFT? {
+        access(all) fun borrowExampleNFT2(id: UInt64): &ExampleNFT2.NFT? {
             if self.ownedNFTs[id] != nil {
                 // Create an authorized reference to allow downcasting
-                let ref = (&self.ownedNFTs[id] as auth &NonFungibleToken.NFT?)!
+                let ref = (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)!
                 return ref as! &ExampleNFT2.NFT
             }
 
             return nil
         }
 
-        /// Gets a reference to the NFT only conforming to the `{MetadataViews.Resolver}`
-        /// interface so that the caller can retrieve the views that the NFT
-        /// is implementing and resolve them
-        ///
-        /// @param id: The ID of the wanted NFT
-        /// @return The resource reference conforming to the Resolver interface
-        /// 
-        pub fun borrowViewResolver(id: UInt64): &AnyResource{MetadataViews.Resolver} {
-            let nft = (&self.ownedNFTs[id] as auth &NonFungibleToken.NFT?)!
-            let exampleNFT = nft as! &ExampleNFT2.NFT
-            return exampleNFT as &AnyResource{MetadataViews.Resolver}
+        access(all) fun createEmptyCollection(): @{NonFungibleToken.Collection} {
+            return <- create Collection()
         }
 
-        destroy() {
-            destroy self.ownedNFTs
+        access(all) view fun getSupportedNFTTypes(): {Type: Bool} {
+            return {
+                Type<@ExampleNFT2.NFT>(): true
+            }
+        }
+
+        access(all) view fun isSupportedNFTType(type: Type): Bool {
+            return type == Type<@ExampleNFT2.NFT>()
         }
     }
 
-    /// Allows anyone to create a new empty collection
-    ///
-    /// @return The new Collection resource
-    ///
-    pub fun createEmptyCollection(): @NonFungibleToken.Collection {
+    // public function that anyone can call to create a new empty collection
+    access(all) fun createEmptyCollection(): @{NonFungibleToken.Collection} {
         return <- create Collection()
     }
 
-    /// Resource that an admin or something similar would own to be
-    /// able to mint new NFTs
-    ///
-    pub resource NFTMinter {
+    // Resource that an admin or something similar would own to be
+    // able to mint new NFTs
+    //
+    access(all) resource NFTMinter {
 
-        /// Mints a new NFT with a new ID and deposit it in the
-        /// recipients collection using their collection reference
-        ///
-        /// @param recipient: A capability to the collection where the new NFT will be deposited
-        /// @param name: The name for the NFT metadata
-        /// @param description: The description for the NFT metadata
-        /// @param thumbnail: The thumbnail for the NFT metadata
-        /// @param royalties: An array of Royalty structs, see MetadataViews docs 
-        ///     
-        pub fun mintNFT(
+        // mintNFT mints a new NFT with a new ID
+        // and deposit it in the recipients collection using their collection reference
+        access(all) fun mintNFT(
             recipient: &{NonFungibleToken.CollectionPublic},
             name: String,
             description: String,
             thumbnail: String,
-            royalties: [MetadataViews.Royalty]
+            royaltyReceipient: Address,
         ) {
-            let metadata: {String: AnyStruct} = {}
-            let currentBlock = getCurrentBlock()
-            metadata["mintedBlock"] = currentBlock.height
-            metadata["mintedTime"] = currentBlock.timestamp
-            metadata["minter"] = recipient.owner!.address
+            ExampleNFT2.totalSupply = ExampleNFT2.totalSupply + 1
+            self.mintNFTWithId(recipient: recipient, name: name, description: description, thumbnail: thumbnail, royaltyReceipient: royaltyReceipient, id: ExampleNFT2.totalSupply)
+        }
 
-            // this piece of metadata will be used to show embedding rarity into a trait
-            metadata["foo"] = "bar"
+        access(all) fun mintNFTWithId(
+            recipient: &{NonFungibleToken.CollectionPublic},
+            name: String,
+            description: String,
+            thumbnail: String,
+            royaltyReceipient: Address,
+            id: UInt64
+        ) {
+            let royaltyRecipient = getAccount(royaltyReceipient).capabilities.get<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)!
+            let cutInfo = MetadataViews.Royalty(receiver: royaltyRecipient, cut: 0.05, description: "")
+            // create a new NFT
+            var newNFT <- create NFT(
+                id: id,
+                name: name,
+                description: description,
+                thumbnail: thumbnail,
+                royalties: [cutInfo]
+            )
+
+            // deposit it in the recipient's account using their reference
+            recipient.deposit(token: <-newNFT)
+        }
+
+        // mintNFT mints a new NFT with a new ID
+        // and deposit it in the recipients collection using their collection reference
+        access(all) fun mintNFTWithRoyaltyCuts(
+            recipient: &{NonFungibleToken.CollectionPublic},
+            name: String,
+            description: String,
+            thumbnail: String,
+            royaltyReceipients: [Address],
+            royaltyCuts: [UFix64]
+        ) {
+            assert(royaltyReceipients.length == royaltyCuts.length, message: "mismatched royalty recipients and cuts")
+            let royalties: [MetadataViews.Royalty] = []
+
+            var index = 0
+            while index < royaltyReceipients.length {
+                let royaltyRecipient = getAccount(royaltyReceipients[index]).capabilities.get<&{FungibleToken.Receiver}>(/public/placeholder)!
+                let cutInfo = MetadataViews.Royalty(receiver: royaltyRecipient, cut: royaltyCuts[index], description: "")
+                royalties.append(cutInfo)
+                index = index + 1
+            }            
+
+            ExampleNFT2.totalSupply = ExampleNFT2.totalSupply + 1
 
             // create a new NFT
             var newNFT <- create NFT(
@@ -318,14 +289,11 @@ pub contract ExampleNFT2: NonFungibleToken, ViewResolver {
                 name: name,
                 description: description,
                 thumbnail: thumbnail,
-                royalties: royalties,
-                metadata: metadata,
+                royalties: royalties
             )
 
             // deposit it in the recipient's account using their reference
             recipient.deposit(token: <-newNFT)
-
-            ExampleNFT2.totalSupply = ExampleNFT2.totalSupply + UInt64(1)
         }
     }
 
@@ -334,19 +302,17 @@ pub contract ExampleNFT2: NonFungibleToken, ViewResolver {
     /// @param view: The Type of the desired view.
     /// @return A structure representing the requested view.
     ///
-    pub fun resolveView(_ view: Type): AnyStruct? {
-        switch view {
+    access(all) fun resolveContractView(resourceType: Type?, viewType: Type): AnyStruct? {
+        switch viewType {
             case Type<MetadataViews.NFTCollectionData>():
                 return MetadataViews.NFTCollectionData(
-                    storagePath: ExampleNFT2.CollectionStoragePath,
-                    publicPath: ExampleNFT2.CollectionPublicPath,
-                    providerPath: /private/exampleNFT2Collection,
-                    publicCollection: Type<&ExampleNFT2.Collection{ExampleNFT2.ExampleNFT2CollectionPublic}>(),
-                    publicLinkedType: Type<&ExampleNFT2.Collection{ExampleNFT2.ExampleNFT2CollectionPublic,NonFungibleToken.CollectionPublic,NonFungibleToken.Receiver,MetadataViews.ResolverCollection}>(),
-                    providerLinkedType: Type<&ExampleNFT2.Collection{ExampleNFT2.ExampleNFT2CollectionPublic,NonFungibleToken.CollectionPublic,NonFungibleToken.Provider,MetadataViews.ResolverCollection}>(),
-                    createEmptyCollectionFunction: (fun (): @NonFungibleToken.Collection {
-                        return <-ExampleNFT2.createEmptyCollection()
-                    })
+                        storagePath: ExampleNFT2.CollectionStoragePath,
+                        publicPath: ExampleNFT2.CollectionPublicPath,
+                        publicCollection: Type<&ExampleNFT2.Collection>(),
+                        publicLinkedType: Type<&ExampleNFT2.Collection>(),
+                        createEmptyCollectionFunction: (fun (): @{NonFungibleToken.Collection} {
+                            return <-ExampleNFT2.createEmptyCollection()
+                        })
                 )
             case Type<MetadataViews.NFTCollectionDisplay>():
                 let media = MetadataViews.Media(
@@ -354,6 +320,16 @@ pub contract ExampleNFT2: NonFungibleToken, ViewResolver {
                         url: "https://assets.website-files.com/5f6294c0c7a8cdd643b1c820/5f6294c0c7a8cda55cb1c936_Flow_Wordmark.svg"
                     ),
                     mediaType: "image/svg+xml"
+                )
+                return MetadataViews.NFTCollectionDisplay(
+                    name: "The Example Collection",
+                    description: "This collection is used as an example to help you develop your next Flow NFT.",
+                    externalURL: MetadataViews.ExternalURL("https://example-nft.onflow.org"),
+                    squareImage: media,
+                    bannerImage: media,
+                    socials: {
+                        "twitter": MetadataViews.ExternalURL("https://twitter.com/flow_blockchain")
+                    }
                 )
         }
         return nil
@@ -364,7 +340,7 @@ pub contract ExampleNFT2: NonFungibleToken, ViewResolver {
     /// @return An array of Types defining the implemented views. This value will be used by
     ///         developers to know which parameter to pass to the resolveView() method.
     ///
-    pub fun getViews(): [Type] {
+    access(all) view fun getContractViews(resourceType: Type?): [Type] {
         return [
             Type<MetadataViews.NFTCollectionData>(),
             Type<MetadataViews.NFTCollectionDisplay>()
@@ -379,20 +355,20 @@ pub contract ExampleNFT2: NonFungibleToken, ViewResolver {
         self.CollectionStoragePath = /storage/exampleNFT2Collection
         self.CollectionPublicPath = /public/exampleNFT2Collection
         self.MinterStoragePath = /storage/exampleNFT2Minter
+        self.MinterPublicPath = /public/exampleNFT2Minter
 
         // Create a Collection resource and save it to storage
         let collection <- create Collection()
-        self.account.save(<-collection, to: self.CollectionStoragePath)
+        self.account.storage.save(<-collection, to: self.CollectionStoragePath)
+        let cap = self.account.capabilities.storage.issue<&ExampleNFT2.Collection>(self.CollectionStoragePath)
+        self.account.capabilities.publish(cap, at: self.CollectionPublicPath)
 
-        // create a public capability for the collection
-        self.account.link<&ExampleNFT2.Collection{NonFungibleToken.CollectionPublic, ExampleNFT2.ExampleNFT2CollectionPublic, MetadataViews.ResolverCollection}>(
-            self.CollectionPublicPath,
-            target: self.CollectionStoragePath
-        )
 
         // Create a Minter resource and save it to storage
         let minter <- create NFTMinter()
-        self.account.save(<-minter, to: self.MinterStoragePath)
+        self.account.storage.save(<-minter, to: self.MinterStoragePath)
+
+        let minterCap = self.account.capabilities.storage.issue<&ExampleNFT2.NFTMinter>(self.MinterStoragePath)
 
         emit ContractInitialized()
     }

--- a/contracts/standard/ExampleToken.cdc
+++ b/contracts/standard/ExampleToken.cdc
@@ -276,6 +276,12 @@ access(all) contract ExampleToken: FungibleToken {
         return nil
     }
 
+    // EMULATOR ONLY, anyone can mint tokens
+    access(all) fun createNewMinter(allowedAmount: UFix64): @Minter {
+        emit MinterCreated(allowedAmount: allowedAmount)
+        return <-create Minter(allowedAmount: allowedAmount)
+    }
+
     init() {
         self.totalSupply = 1000.0
 

--- a/contracts/standard/ExampleToken.cdc
+++ b/contracts/standard/ExampleToken.cdc
@@ -1,38 +1,49 @@
 import "FungibleToken"
 import "MetadataViews"
+import "FungibleTokenMetadataViews"
 
-pub contract ExampleToken: FungibleToken {
+access(all) contract ExampleToken: FungibleToken {
 
     /// Total supply of ExampleTokens in existence
-    pub var totalSupply: UFix64
-    
-    /// Storage and Public Paths
-    pub let VaultStoragePath: StoragePath
-    pub let VaultPublicPath: PublicPath
-    pub let ReceiverPublicPath: PublicPath
-    pub let AdminStoragePath: StoragePath
+    access(all) var totalSupply: UFix64
 
+    /// TokensInitialized
+    ///
     /// The event that is emitted when the contract is created
-    pub event TokensInitialized(initialSupply: UFix64)
+    access(all) event TokensInitialized(initialSupply: UFix64)
 
+    /// TokensWithdrawn
+    ///
     /// The event that is emitted when tokens are withdrawn from a Vault
-    pub event TokensWithdrawn(amount: UFix64, from: Address?)
+    access(all) event TokensWithdrawn(amount: UFix64, from: Address?)
 
+    /// TokensDeposited
+    ///
     /// The event that is emitted when tokens are deposited to a Vault
-    pub event TokensDeposited(amount: UFix64, to: Address?)
+    access(all) event TokensDeposited(amount: UFix64, to: Address?)
 
+    /// TokensMinted
+    ///
     /// The event that is emitted when new tokens are minted
-    pub event TokensMinted(amount: UFix64)
+    access(all) event TokensMinted(amount: UFix64)
 
+    /// TokensBurned
+    ///
     /// The event that is emitted when tokens are destroyed
-    pub event TokensBurned(amount: UFix64)
+    access(all) event TokensBurned(amount: UFix64)
 
+    /// MinterCreated
+    ///
     /// The event that is emitted when a new minter resource is created
-    pub event MinterCreated(allowedAmount: UFix64)
+    access(all) event MinterCreated(allowedAmount: UFix64)
 
+    /// BurnerCreated
+    ///
     /// The event that is emitted when a new burner resource is created
-    pub event BurnerCreated()
+    access(all) event BurnerCreated()
 
+    /// Vault
+    ///
     /// Each user stores an instance of only the Vault in their storage
     /// The functions in the Vault and governed by the pre and post conditions
     /// in FungibleToken when they are called.
@@ -43,41 +54,76 @@ pub contract ExampleToken: FungibleToken {
     /// out of thin air. A special Minter resource needs to be defined to mint
     /// new tokens.
     ///
-    pub resource Vault: FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance {
+    access(all) resource Vault: FungibleToken.Vault {
 
         /// The total balance of this vault
-        pub var balance: UFix64
+        access(all) var balance: UFix64
 
-        /// Initialize the balance at resource creation time
+        // initialize the balance at resource creation time
         init(balance: UFix64) {
             self.balance = balance
         }
 
+        access(all) view fun isAvailableToWithdraw(amount: UFix64): Bool {
+            return amount <= self.balance
+        }
+
+        access(all) view fun getSupportedVaultTypes(): {Type: Bool} {
+            return {self.getType(): true}
+        }
+
+        access(all) view fun isSupportedVaultType(type: Type): Bool {
+            if (type == self.getType()) { return true } else { return false }
+        }
+
+        access(all) fun createEmptyVault(): @{FungibleToken.Vault} {
+            return <-create Vault(balance: 0.0)
+        }
+
+        /// Get all the Metadata Views implemented by ExampleToken
+        ///
+        /// @return An array of Types defining the implemented views. This value will be used by
+        ///         developers to know which parameter to pass to the resolveView() method.
+        ///
+        access(all) view fun getViews(): [Type]{
+            return ExampleToken.getContractViews(resourceType: nil)
+        }
+
+        /// Get a Metadata View from ExampleToken
+        ///
+        /// @param view: The Type of the desired view.
+        /// @return A structure representing the requested view.
+        ///
+        access(all) fun resolveView(_ view: Type): AnyStruct? {
+            return ExampleToken.resolveContractView(resourceType: nil, viewType: view)
+        }
+
+        /// withdraw
+        ///
         /// Function that takes an amount as an argument
         /// and withdraws that amount from the Vault.
+        ///
         /// It creates a new temporary Vault that is used to hold
         /// the money that is being transferred. It returns the newly
         /// created Vault to the context that called so it can be deposited
         /// elsewhere.
         ///
-        /// @param amount: The amount of tokens to be withdrawn from the vault
-        /// @return The Vault resource containing the withdrawn funds
-        ///
-        pub fun withdraw(amount: UFix64): @FungibleToken.Vault {
+        access(FungibleToken.Withdraw) fun withdraw(amount: UFix64): @{FungibleToken.Vault} {
             self.balance = self.balance - amount
             emit TokensWithdrawn(amount: amount, from: self.owner?.address)
             return <-create Vault(balance: amount)
         }
 
+        /// deposit
+        ///
         /// Function that takes a Vault object as an argument and adds
         /// its balance to the balance of the owners Vault.
+        ///
         /// It is allowed to destroy the sent Vault because the Vault
         /// was a temporary holder of the tokens. The Vault's balance has
         /// been consumed and therefore can be destroyed.
         ///
-        /// @param from: The Vault resource containing the funds that will be deposited
-        ///
-        pub fun deposit(from: @FungibleToken.Vault) {
+        access(all) fun deposit(from: @{FungibleToken.Vault}) {
             let vault <- from as! @ExampleToken.Vault
             self.balance = self.balance + vault.balance
             emit TokensDeposited(amount: vault.balance, to: self.owner?.address)
@@ -85,64 +131,58 @@ pub contract ExampleToken: FungibleToken {
             destroy vault
         }
 
-        destroy() {
-            if self.balance > 0.0 {
-                ExampleToken.totalSupply = ExampleToken.totalSupply - self.balance
-            }
+        access(contract) fun burnCallback() {
+            ExampleToken.totalSupply = ExampleToken.totalSupply - self.balance
         }
-
     }
 
+    /// createEmptyVault
+    ///
     /// Function that creates a new Vault with a balance of zero
     /// and returns it to the calling context. A user must call this function
     /// and store the returned Vault in their storage in order to allow their
     /// account to be able to receive deposits of this token type.
     ///
-    /// @return The new Vault resource
-    ///
-    pub fun createEmptyVault(): @Vault {
+    access(all) fun createEmptyVault(vaultType: Type): @Vault {
         return <-create Vault(balance: 0.0)
     }
 
-    pub resource Administrator {
+    access(all) resource Administrator {
 
+        /// createNewMinter
+        ///
         /// Function that creates and returns a new minter resource
         ///
-        /// @param allowedAmount: The maximum quantity of tokens that the minter could create
-        /// @return The Minter resource that would allow to mint tokens
-        ///
-        
+        access(all) fun createNewMinter(allowedAmount: UFix64): @Minter {
+            emit MinterCreated(allowedAmount: allowedAmount)
+            return <-create Minter(allowedAmount: allowedAmount)
+        }
 
+        /// createNewBurner
+        ///
         /// Function that creates and returns a new burner resource
         ///
-        /// @return The Burner resource
-        ///
-        pub fun createNewBurner(): @Burner {
+        access(all) fun createNewBurner(): @Burner {
             emit BurnerCreated()
             return <-create Burner()
         }
     }
 
-    // EMULATOR ONLY, anyone can mint tokens
-    pub fun createNewMinter(allowedAmount: UFix64): @Minter {
-            emit MinterCreated(allowedAmount: allowedAmount)
-            return <-create Minter(allowedAmount: allowedAmount)
-        }
-
+    /// Minter
+    ///
     /// Resource object that token admin accounts can hold to mint new tokens.
     ///
-    pub resource Minter {
+    access(all) resource Minter {
 
         /// The amount of tokens that the minter is allowed to mint
-        pub var allowedAmount: UFix64
+        access(all) var allowedAmount: UFix64
 
+        /// mintTokens
+        ///
         /// Function that mints new tokens, adds them to the total supply,
         /// and returns them to the calling context.
         ///
-        /// @param amount: The quantity of tokens to mint
-        /// @return The Vault resource containing the minted tokens
-        ///
-        pub fun mintTokens(amount: UFix64): @ExampleToken.Vault {
+        access(all) fun mintTokens(amount: UFix64): @ExampleToken.Vault {
             pre {
                 amount > 0.0: "Amount minted must be greater than zero"
                 amount <= self.allowedAmount: "Amount minted must be less than the allowed amount"
@@ -158,18 +198,20 @@ pub contract ExampleToken: FungibleToken {
         }
     }
 
+    /// Burner
+    ///
     /// Resource object that token admin accounts can hold to burn tokens.
     ///
-    pub resource Burner {
+    access(all) resource Burner {
 
+        /// burnTokens
+        ///
         /// Function that destroys a Vault instance, effectively burning the tokens.
         ///
         /// Note: the burned tokens are automatically subtracted from the
         /// total supply in the Vault destructor.
         ///
-        /// @param from: The Vault resource containing the tokens to burn
-        ///
-        pub fun burnTokens(from: @FungibleToken.Vault) {
+        access(all) fun burnTokens(from: @{FungibleToken.Vault}) {
             let vault <- from as! @ExampleToken.Vault
             let amount = vault.balance
             destroy vault
@@ -177,35 +219,81 @@ pub contract ExampleToken: FungibleToken {
         }
     }
 
+    /// Gets a list of the metadata views that this contract supports
+    access(all) view fun getContractViews(resourceType: Type?): [Type] {
+        return [Type<FungibleTokenMetadataViews.FTView>(),
+                Type<FungibleTokenMetadataViews.FTDisplay>(),
+                Type<FungibleTokenMetadataViews.FTVaultData>(),
+                Type<FungibleTokenMetadataViews.TotalSupply>()]
+    }
+
+    /// Get a Metadata View from ExampleToken
+    ///
+    /// @param view: The Type of the desired view.
+    /// @return A structure representing the requested view.
+    ///
+    access(all) fun resolveContractView(resourceType: Type?, viewType: Type): AnyStruct? {
+        switch viewType {
+            case Type<FungibleTokenMetadataViews.FTView>():
+                return FungibleTokenMetadataViews.FTView(
+                    ftDisplay: self.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTDisplay>()) as! FungibleTokenMetadataViews.FTDisplay?,
+                    ftVaultData: self.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>()) as! FungibleTokenMetadataViews.FTVaultData?
+                )
+            case Type<FungibleTokenMetadataViews.FTDisplay>():
+                let media = MetadataViews.Media(
+                        file: MetadataViews.HTTPFile(
+                        url: "example.com"
+                    ),
+                    mediaType: "image/svg+xml"
+                )
+                let medias = MetadataViews.Medias([media])
+                return FungibleTokenMetadataViews.FTDisplay(
+                    name: "EXAMPLE Token",
+                    symbol: "EXAMPLE",
+                    description: "This is an example token",
+                    externalURL: MetadataViews.ExternalURL("https://flow.com"),
+                    logos: medias,
+                    socials: {
+                        "twitter": MetadataViews.ExternalURL("https://twitter.com/flow_blockchain")
+                    }
+                )
+            case Type<FungibleTokenMetadataViews.FTVaultData>():
+                let vaultRef = ExampleToken.account.storage.borrow<auth(FungibleToken.Withdraw) &ExampleToken.Vault>(from: /storage/exampleTokenVault)
+			        ?? panic("Could not borrow reference to the contract's Vault!")
+                return FungibleTokenMetadataViews.FTVaultData(
+                    storagePath: /storage/exampleTokenVault,
+                    receiverPath: /public/exampleTokenReceiver,
+                    metadataPath: /public/exampleTokenBalance,
+                    receiverLinkedType: Type<&{FungibleToken.Receiver, FungibleToken.Vault}>(),
+                    metadataLinkedType: Type<&{FungibleToken.Balance, FungibleToken.Vault}>(),
+                    createEmptyVaultFunction: (fun (): @{FungibleToken.Vault} {
+                        return <-vaultRef.createEmptyVault()
+                    })
+                )
+            case Type<FungibleTokenMetadataViews.TotalSupply>():
+                return FungibleTokenMetadataViews.TotalSupply(totalSupply: ExampleToken.totalSupply)
+        }
+        return nil
+    }
+
     init() {
         self.totalSupply = 1000.0
-        self.VaultStoragePath = /storage/exampleTokenVault
-        self.VaultPublicPath = /public/exampleTokenMetadata
-        self.ReceiverPublicPath = /public/exampleTokenReceiver
-        self.AdminStoragePath = /storage/exampleTokenAdmin
 
-        // Create the Vault with the total supply of tokens and save it in storage.
+        // Create the Vault with the total supply of tokens and save it in storage
+        //
         let vault <- create Vault(balance: self.totalSupply)
-        self.account.save(<-vault, to: self.VaultStoragePath)
+        self.account.storage.save(<-vault, to: /storage/exampleTokenVault)
 
-        // Create a public capability to the stored Vault that exposes
-        // the `deposit` method through the `Receiver` interface.
-        self.account.link<&{FungibleToken.Receiver}>(
-            self.ReceiverPublicPath,
-            target: self.VaultStoragePath
-        )
+        let cap = self.account.capabilities.storage.issue<&{FungibleToken.Vault}>(/storage/exampleTokenVault)
+        self.account.capabilities.publish(cap, at: /public/exampleTokenReceiver)
+        self.account.capabilities.publish(cap, at: /public/exampleTokenBalance)
 
-        // Create a public capability to the stored Vault that only exposes
-        // the `balance` field and the `resolveView` method through the `Balance` interface
-        self.account.link<&ExampleToken.Vault{FungibleToken.Balance}>(
-            self.VaultPublicPath,
-            target: self.VaultStoragePath
-        )
 
         let admin <- create Administrator()
-        self.account.save(<-admin, to: self.AdminStoragePath)
+        self.account.storage.save(<-admin, to: /storage/exampleTokenAdmin)
 
         // Emit an event that shows that the contract was initialized
+        //
         emit TokensInitialized(initialSupply: self.totalSupply)
     }
 }

--- a/flow.json
+++ b/flow.json
@@ -28,7 +28,7 @@
       }
     },
     "ExampleNFT": {
-      "source": "./modules/flow-nft/contracts/ExampleNFT.cdc",
+      "source": "./contracts/standard/ExampleNFT.cdc",
       "aliases": {
         "testing": "0000000000000007"
       }

--- a/flow.json
+++ b/flow.json
@@ -1,21 +1,5 @@
 {
   "contracts": {
-    "AddressUtils": {
-      "source": "./modules/flow-utils/cadence/contracts/AddressUtils.cdc",
-      "aliases": {
-        "emulator": "f8d6e0586b0a20c7",
-        "testnet": "31ad40c07a2a9788",
-        "mainnet": "a340dc0a4ec828ab"
-      }
-    },
-    "ArrayUtils": {
-      "source": "./modules/flow-utils/cadence/contracts/ArrayUtils.cdc",
-      "aliases": {
-        "emulator": "f8d6e0586b0a20c7",
-        "testnet": "31ad40c07a2a9788",
-        "mainnet": "a340dc0a4ec828ab"
-      }
-    },
     "CapabilityDelegator": {
       "source": "./contracts/CapabilityDelegator.cdc",
       "aliases": {
@@ -106,22 +90,6 @@
         "mainnet": "d8a7e05a7ac670c0"
       }
     },
-    "FlowToken": {
-      "source": "",
-      "aliases": {
-        "emulator": "0ae53cb6e3f42a79",
-        "testnet": "7e60df042a9c0868",
-        "mainnet": "1654653399040a61"
-      }
-    },
-    "FungibleToken": {
-      "source": "./modules/flow-nft/contracts/utility/FungibleToken.cdc",
-      "aliases": {
-        "emulator": "ee82856bf20e2aa6",
-        "testnet": "9a0766d93b6608b7",
-        "mainnet": "f233dcee88fe0abe"
-      }
-    },
     "HybridCustody": {
       "source": "./contracts/HybridCustody.cdc",
       "aliases": {
@@ -129,14 +97,6 @@
         "testing": "0000000000000007",
         "testnet": "294e44e1ec6993c6",
         "mainnet": "d8a7e05a7ac670c0"
-      }
-    },
-    "MetadataViews": {
-      "source": "./modules/flow-nft/contracts/MetadataViews.cdc",
-      "aliases": {
-        "emulator": "f8d6e0586b0a20c7",
-        "testnet": "631e88ae7f1d7c20",
-        "mainnet": "1d7e57aa55817448"
       }
     },
     "NFTCollectionPublicFactory": {
@@ -165,28 +125,84 @@
         "testnet": "294e44e1ec6993c6"
       }
     },
-    "NonFungibleToken": {
-      "source": "./modules/flow-nft/contracts/NonFungibleToken.cdc",
+    "FungibleToken": {
+      "source": "./node_modules/@flowtyio/flow-contracts/contracts/FungibleToken.cdc",
       "aliases": {
-        "emulator": "f8d6e0586b0a20c7",
-        "testnet": "631e88ae7f1d7c20",
-        "mainnet": "1d7e57aa55817448"
+        "emulator": "0xee82856bf20e2aa6",
+        "testnet": "0x9a0766d93b6608b7",
+        "mainnet": "0xf233dcee88fe0abe"
+      }
+    },
+    "FungibleTokenMetadataViews": {
+      "source": "./node_modules/@flowtyio/flow-contracts/contracts/FungibleTokenMetadataViews.cdc",
+      "aliases": {
+        "emulator": "0xee82856bf20e2aa6",
+        "testnet": "0x9a0766d93b6608b7",
+        "mainnet": "0xf233dcee88fe0abe"
+      }
+    },
+    "Burner": {
+      "source": "./node_modules/@flowtyio/flow-contracts/contracts/Burner.cdc",
+      "aliases": {
+        "emulator": "0xf8d6e0586b0a20c7",
+        "testnet": "0x631e88ae7f1d7c20",
+        "mainnet": "0x1d7e57aa55817448"
+      }
+    },
+    "FlowToken": {
+      "source": "./node_modules/@flowtyio/flow-contracts/contracts/FlowToken.cdc",
+      "aliases": {
+        "emulator": "0x0ae53cb6e3f42a79",
+        "testnet": "0x7e60df042a9c0868",
+        "mainnet": "0x1654653399040a61"
+      }
+    },
+    "NonFungibleToken": {
+      "source": "./node_modules/@flowtyio/flow-contracts/contracts/NonFungibleToken.cdc",
+      "aliases": {
+        "emulator": "0xf8d6e0586b0a20c7",
+        "testnet": "0x631e88ae7f1d7c20",
+        "mainnet": "0x1d7e57aa55817448"
       }
     },
     "StringUtils": {
-      "source": "./modules/flow-utils/cadence/contracts/StringUtils.cdc",
+      "source": "./node_modules/@flowtyio/flow-contracts/contracts/flow-utils/StringUtils.cdc",
       "aliases": {
-        "emulator": "f8d6e0586b0a20c7",
-        "testnet": "31ad40c07a2a9788",
-        "mainnet": "a340dc0a4ec828ab"
+        "emulator": "0xf8d6e0586b0a20c7",
+        "testnet": "0x31ad40c07a2a9788",
+        "mainnet": "0xa340dc0a4ec828ab"
+      }
+    },
+    "ArrayUtils": {
+      "source": "./node_modules/@flowtyio/flow-contracts/contracts/flow-utils/ArrayUtils.cdc",
+      "aliases": {
+        "emulator": "0xf8d6e0586b0a20c7",
+        "testnet": "0x31ad40c07a2a9788",
+        "mainnet": "0xa340dc0a4ec828ab"
+      }
+    },
+    "AddressUtils": {
+      "source": "./node_modules/@flowtyio/flow-contracts/contracts/flow-utils/AddressUtils.cdc",
+      "aliases": {
+        "emulator": "0xf8d6e0586b0a20c7",
+        "testnet": "0x31ad40c07a2a9788",
+        "mainnet": "0xa340dc0a4ec828ab"
+      }
+    },
+    "MetadataViews": {
+      "source": "./node_modules/@flowtyio/flow-contracts/contracts/MetadataViews.cdc",
+      "aliases": {
+        "emulator": "0xf8d6e0586b0a20c7",
+        "testnet": "0x631e88ae7f1d7c20",
+        "mainnet": "0x1d7e57aa55817448"
       }
     },
     "ViewResolver": {
-      "source": "./modules/flow-nft/contracts/ViewResolver.cdc",
+      "source": "./node_modules/@flowtyio/flow-contracts/contracts/ViewResolver.cdc",
       "aliases": {
-        "emulator": "f8d6e0586b0a20c7",
-        "testnet": "631e88ae7f1d7c20",
-        "mainnet": "1d7e57aa55817448"
+        "emulator": "0xf8d6e0586b0a20c7",
+        "testnet": "0x631e88ae7f1d7c20",
+        "mainnet": "0x1d7e57aa55817448"
       }
     }
   },
@@ -285,6 +301,10 @@
         "hashAlgorithm": "SHA2_256",
         "resourceID": "projects/dl-flow-admin/locations/global/keyRings/hybrid-custody-testnet/cryptoKeys/hybrid-custody-testnet-key/cryptoKeyVersions/1"
       }
+    },
+    "emulator-flowtoken": {
+      "address": "0ae53cb6e3f42a79",
+      "key": "686779d775e5fcbf8d2f4a85cb4c53525d02b7ef53230d180fc16f35d9b7d025"
     }
   },
   "deployments": {
@@ -310,10 +330,15 @@
         "NFTCollectionPublicFactory",
         "ExampleNFT",
         "ExampleNFT2",
-        "ExampleToken"
+        "ExampleToken",
+        "Burner"
       ],
       "emulator-ft": [
-        "FungibleToken"
+        "FungibleToken",
+        "FungibleTokenMetadataViews"
+      ],
+      "emulator-flowtoken": [
+        "FlowToken"
       ]
     },
     "testnet": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,35 @@
+{
+  "name": "hybrid-custody",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hybrid-custody",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@flowtyio/flow-contracts": "^0.1.0-beta.11"
+      }
+    },
+    "node_modules/@flowtyio/flow-contracts": {
+      "version": "0.1.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@flowtyio/flow-contracts/-/flow-contracts-0.1.0-beta.11.tgz",
+      "integrity": "sha512-4D1JHCrV6KxRgKEsfGxzVxAYrEjq51N0tlVy7gi+Ne7YhWQ+Jp7ha+QwPxuLIYkjMZjMzoM/dD6WedZQERgFSg==",
+      "dependencies": {
+        "commander": "^11.0.0"
+      },
+      "bin": {
+        "flow-contracts": "index.js"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "hybrid-custody",
+  "version": "1.0.0",
+  "description": "![Tests](https://github.com/onflow/hybrid-custody/actions/workflows/integration-tests.yml/badge.svg) [![codecov](https://codecov.io/gh/onflow/hybrid-custody/branch/main/graph/badge.svg?token=5GWD5NHEKF)](https://codecov.io/gh/onflow/hybrid-custody)",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@flowtyio/flow-contracts": "^0.1.0-beta.11"
+  }
+}

--- a/scripts/delegator/find_nft_collection_cap.cdc
+++ b/scripts/delegator/find_nft_collection_cap.cdc
@@ -3,14 +3,14 @@ import "CapabilityDelegator"
 import "NonFungibleToken"
 import "ExampleNFT"
 
-pub fun main(addr: Address): Bool {
+access(all) fun main(addr: Address): Bool {
     let acct = getAccount(addr)
 
     let delegator = 
-        acct.getCapability<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPublic}>(CapabilityDelegator.PublicPath).borrow()
+        acct.capabilities.get<&{CapabilityDelegator.GetterPublic}>(CapabilityDelegator.PublicPath)!.borrow()
         ?? panic("could not borrow delegator")
 
-    let desiredType = Type<Capability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic}>>()
+    let desiredType = Type<Capability<&{ExampleNFT.ExampleNFTCollectionPublic}>>()
     let foundType = delegator.findFirstPublicType(desiredType) ?? panic("no type found")
     
     let nakedCap = delegator.getPublicCapability(foundType) ?? panic("requested capability type was not found")

--- a/scripts/delegator/find_nft_provider_cap.cdc
+++ b/scripts/delegator/find_nft_provider_cap.cdc
@@ -3,14 +3,14 @@ import "CapabilityDelegator"
 import "NonFungibleToken"
 import "ExampleNFT"
 
-pub fun main(addr: Address): Bool {
-    let acct = getAuthAccount(addr)
+access(all) fun main(addr: Address): Bool {
+    let acct = getAuthAccount<auth(Capabilities) &Account>(addr)
 
     let delegator = 
-        acct.getCapability<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPrivate}>(CapabilityDelegator.PrivatePath).borrow()
+        acct.capabilities.storage.issue<auth(Capabilities) &{CapabilityDelegator.GetterPrivate}>(CapabilityDelegator.StoragePath).borrow()
         ?? panic("could not borrow delegator")
 
-    let desiredType = Type<Capability<&ExampleNFT.Collection{NonFungibleToken.Provider}>>()
+    let desiredType = Type<Capability<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>>()
     let foundType = delegator.findFirstPrivateType(desiredType) ?? panic("no type found")
     
     let nakedCap = delegator.getPrivateCapability(foundType) ?? panic("requested capability type was not found")

--- a/scripts/delegator/get_all_private_caps.cdc
+++ b/scripts/delegator/get_all_private_caps.cdc
@@ -3,13 +3,13 @@ import "CapabilityDelegator"
 import "NonFungibleToken"
 import "ExampleNFT"
 
-pub fun main(address: Address): Bool {
-    let privateCaps: [Capability] = getAuthAccount(address).getCapability<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPrivate}>(CapabilityDelegator.PrivatePath)
+access(all) fun main(address: Address): Bool {
+    let privateCaps: [Capability] = getAuthAccount<auth(Capabilities) &Account>(address).capabilities.storage.issue<auth(Capabilities) &{CapabilityDelegator.GetterPrivate}>(CapabilityDelegator.StoragePath)
         .borrow()
         ?.getAllPrivate()
         ?? panic("could not borrow delegator")
 
-    let desiredType: Type = Type<Capability<&ExampleNFT.Collection{NonFungibleToken.Provider}>>()
+    let desiredType: Type = Type<Capability<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>>()
 
     return privateCaps.length == 1 && privateCaps[0].getType() == desiredType
 }

--- a/scripts/delegator/get_all_public_caps.cdc
+++ b/scripts/delegator/get_all_public_caps.cdc
@@ -3,12 +3,12 @@ import "CapabilityDelegator"
 import "NonFungibleToken"
 import "ExampleNFT"
 
-pub fun main(address: Address): Bool {
-    let delegator = getAccount(address).getCapability<&{CapabilityDelegator.GetterPublic}>(CapabilityDelegator.PublicPath).borrow()
+access(all) fun main(address: Address): Bool {
+    let delegator = getAccount(address).capabilities.get<&{CapabilityDelegator.GetterPublic}>(CapabilityDelegator.PublicPath)!.borrow()
         ?? panic("delegator not found")
     let publicCaps: [Capability] = delegator.getAllPublic()
     assert(publicCaps.length > 0, message: "no public capabilities found")
     
-    let desiredType: Type = Type<Capability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>>()
+    let desiredType: Type = Type<Capability<&{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>>()
     return publicCaps[0].getType() == desiredType
 }

--- a/scripts/delegator/get_nft_collection.cdc
+++ b/scripts/delegator/get_nft_collection.cdc
@@ -3,19 +3,19 @@ import "CapabilityDelegator"
 import "NonFungibleToken"
 import "ExampleNFT"
 
-pub fun main(addr: Address): Bool {
+access(all) fun main(addr: Address): Bool {
     let acct = getAccount(addr)
 
     let delegator = 
-        acct.getCapability<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPublic}>(CapabilityDelegator.PublicPath).borrow()
+        acct.capabilities.get<&{CapabilityDelegator.GetterPublic}>(CapabilityDelegator.PublicPath)!.borrow()
         ?? panic("could not borrow delegator")
 
-    let capType = Type<Capability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>>()
+    let capType = Type<Capability<&{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>>()
     let nakedCap = delegator.getPublicCapability(capType) ?? panic("requested capability type was not found")
 
     // we don't need to do anything with this cap, being able to cast here is enough to know
     // that this works
-    let cap = nakedCap as! Capability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>
+    let cap = nakedCap as! Capability<&{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>
     
     return true
 }

--- a/scripts/delegator/get_nft_provider.cdc
+++ b/scripts/delegator/get_nft_provider.cdc
@@ -3,19 +3,19 @@ import "CapabilityDelegator"
 import "NonFungibleToken"
 import "ExampleNFT"
 
-pub fun main(addr: Address): Bool {
-    let acct = getAuthAccount(addr)
+access(all) fun main(addr: Address): Bool {
+    let acct = getAuthAccount<auth(Capabilities) &Account>(addr)
 
     let delegator = 
-        acct.getCapability<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPrivate}>(CapabilityDelegator.PrivatePath).borrow()
+        acct.capabilities.storage.issue<auth(Capabilities) &{CapabilityDelegator.GetterPrivate}>(CapabilityDelegator.StoragePath).borrow()
         ?? panic("could not borrow delegator")
 
-    let capType = Type<Capability<&ExampleNFT.Collection{NonFungibleToken.Provider}>>()
+    let capType = Type<Capability<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>>()
     let nakedCap = delegator.getPrivateCapability(capType) ?? panic("requested capability type was not found")
 
     // we don't need to do anything with this cap, being able to cast here is enough to know
     // that this works
-    let cap = nakedCap as! Capability<&ExampleNFT.Collection{NonFungibleToken.Provider}>
+    let cap = nakedCap as! Capability<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>
     
     return true
 }

--- a/scripts/example-nft-2/get_ids.cdc
+++ b/scripts/example-nft-2/get_ids.cdc
@@ -1,8 +1,8 @@
 import "ExampleNFT2"
 
-pub fun main(addr: Address): [UInt64] {
-    let acct = getAuthAccount(addr)
-    let collection = acct.borrow<&ExampleNFT2.Collection>(from: ExampleNFT2.CollectionStoragePath)
+access(all) fun main(addr: Address): [UInt64] {
+    let acct = getAuthAccount<auth(Storage) &Account>(addr)
+    let collection = acct.storage.borrow<&ExampleNFT2.Collection>(from: ExampleNFT2.CollectionStoragePath)
         ?? panic("collection not found")
     return collection.getIDs()
 }

--- a/scripts/example-nft/get_ids.cdc
+++ b/scripts/example-nft/get_ids.cdc
@@ -1,8 +1,8 @@
 import "ExampleNFT"
 
-pub fun main(addr: Address): [UInt64] {
-    let acct = getAuthAccount(addr)
-    let collection = acct.borrow<&ExampleNFT.Collection>(from: ExampleNFT.CollectionStoragePath)
+access(all) fun main(addr: Address): [UInt64] {
+    let acct = getAuthAccount<auth(Storage) &Account>(addr)
+    let collection = acct.storage.borrow<&ExampleNFT.Collection>(from: ExampleNFT.CollectionStoragePath)
         ?? panic("collection not found")
     return collection.getIDs()
 }

--- a/scripts/example-nft/mint_to_account.cdc
+++ b/scripts/example-nft/mint_to_account.cdc
@@ -6,15 +6,16 @@ import "ExampleNFT"
 transaction(receiver: Address, name: String, description: String, thumbnail: String) {
     let minter: &ExampleNFT.NFTMinter
 
-    prepare(acct: AuthAccount) {
-        self.minter = acct.borrow<&ExampleNFT.NFTMinter>(from: ExampleNFT.MinterStoragePath) ?? panic("minter not found")
+    prepare(acct: auth(BorrowValue) &Account) {
+        self.minter = acct.storage.borrow<&ExampleNFT.NFTMinter>(from: ExampleNFT.MinterStoragePath) ?? panic("minter not found")
     }
 
     execute {
-        let d = ExampleNFT.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
+        let d = ExampleNFT.resolveContractView(resourceType: nil, viewType: Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
 
-        let c = getAccount(receiver).getCapability<&{NonFungibleToken.CollectionPublic}>(d.publicPath)
-        let r = c.borrow() ?? panic("no receiver collection")
-        self.minter.mintNFT(recipient: r, name: name, description: description, thumbnail: thumbnail, royalties: [])
+        let c = getAccount(receiver).capabilities.get<&{NonFungibleToken.CollectionPublic}>(d.publicPath)
+            ?? panic("no receiver capability found")
+        let r = c.borrow() ?? panic("could not borrow collection")
+        self.minter.mintNFT(recipient: r, name: name, description: description, thumbnail: thumbnail, royaltyReceipient: self.minter.owner!.address)
     }
 }

--- a/scripts/example-token/get_balance.cdc
+++ b/scripts/example-token/get_balance.cdc
@@ -1,10 +1,14 @@
 import "FungibleToken"
 import "ExampleToken"
+import "FungibleTokenMetadataViews"
 
-pub fun main(account: Address): UFix64 {
+access(all) fun main(account: Address): UFix64 {
     let acct = getAccount(account)
-    let vaultRef = acct.getCapability(ExampleToken.VaultPublicPath)
-        .borrow<&ExampleToken.Vault{FungibleToken.Balance}>()
+
+    let vaultData = ExampleToken.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>()) as! FungibleTokenMetadataViews.FTVaultData?
+        ?? panic("Could not get the vault data view for ExampleToken")
+
+    let vaultRef = acct.capabilities.get<&{FungibleToken.Balance}>(vaultData.metadataPath)!.borrow()
         ?? panic("Could not borrow Balance reference to the Vault")
 
     return vaultRef.balance

--- a/scripts/factory/get_ft_balance_from_factory.cdc
+++ b/scripts/factory/get_ft_balance_from_factory.cdc
@@ -1,13 +1,13 @@
 import "FungibleToken"
 import "ExampleToken"
+import "FungibleTokenMetadataViews"
 
 import "FTBalanceFactory"
 
-pub fun main(addr: Address) {
-    let acct = getAuthAccount(addr)
-    let ref = &acct as &AuthAccount
-
+access(all) fun main(addr: Address) {
+    let acct = getAuthAccount<auth(Capabilities) &Account>(addr)
     let factory = FTBalanceFactory.Factory()
-
-    let provider = factory.getCapability(acct: ref, path: ExampleToken.VaultPublicPath) as! Capability<&{FungibleToken.Balance}>
+    let vaultData = ExampleToken.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>()) as! FungibleTokenMetadataViews.FTVaultData?
+        ?? panic("Could not get the vault data view for ExampleToken")
+    factory.getPublicCapability(acct: acct, path: vaultData.metadataPath)! as! Capability<&{FungibleToken.Balance}>
 }

--- a/scripts/factory/get_ft_provider_from_factory.cdc
+++ b/scripts/factory/get_ft_provider_from_factory.cdc
@@ -1,13 +1,25 @@
 import "FungibleToken"
+import "ExampleToken"
+import "FungibleTokenMetadataViews"
 
 import "FTProviderFactory"
 
-pub fun main(addr: Address) {
-    let acct = getAuthAccount(addr)
-    let ref = &acct as &AuthAccount
-
+access(all) fun main(addr: Address) {
+    let acct = getAuthAccount<auth(Capabilities) &Account>(addr)
     let factory = FTProviderFactory.Factory()
-		let providerPath = /private/exampleTokenProvider
 
-    let provider = factory.getCapability(acct: ref, path: providerPath) as! Capability<&{FungibleToken.Provider}>
+    let vaultData = ExampleToken.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>()) as! FungibleTokenMetadataViews.FTVaultData?
+        ?? panic("Could not get the vault data view for ExampleToken")
+
+    acct.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>(vaultData.storagePath)
+
+    let controllers = acct.capabilities.storage.getControllers(forPath: vaultData.storagePath)
+    for c in controllers {
+        if c.borrowType.isSubtype(of: Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>()) {
+            factory.getCapability(acct: acct, controllerID: c.capabilityID)! as! Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>
+            return 
+        }
+    }
+
+    panic("should not reach this point")
 }

--- a/scripts/factory/get_ft_receiver_from_factory.cdc
+++ b/scripts/factory/get_ft_receiver_from_factory.cdc
@@ -1,13 +1,24 @@
 import "FungibleToken"
 import "ExampleToken"
+import "FungibleTokenMetadataViews"
 
 import "FTReceiverFactory"
 
-pub fun main(addr: Address) {
-    let acct = getAuthAccount(addr)
-    let ref = &acct as &AuthAccount
+access(all) fun main(addr: Address) {
+    let acct = getAuthAccount<auth(Capabilities) &Account>(addr)
 
     let factory = FTReceiverFactory.Factory()
 
-    let receiver = factory.getCapability(acct: ref, path: ExampleToken.ReceiverPublicPath) as! Capability<&{FungibleToken.Receiver}>
+    let vaultData = ExampleToken.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>()) as! FungibleTokenMetadataViews.FTVaultData?
+        ?? panic("Could not get the vault data view for ExampleToken")
+    let controllers = acct.capabilities.storage.getControllers(forPath: vaultData.storagePath)
+
+    for c in controllers {
+        if c.borrowType.isSubtype(of: Type<&{FungibleToken.Receiver}>()) {
+            factory.getCapability(acct: acct, controllerID: c.capabilityID)! as! Capability<&{FungibleToken.Receiver}>
+            return 
+        }
+    }
+
+    panic("should not reach this point")
 }

--- a/scripts/factory/get_supported_types_from_manager.cdc
+++ b/scripts/factory/get_supported_types_from_manager.cdc
@@ -2,8 +2,8 @@ import "CapabilityFactory"
 
 import "NonFungibleToken"
 
-pub fun main(address: Address): [Type] {
-    let getterRef = getAccount(address).getCapability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)
+access(all) fun main(address: Address): [Type] {
+    let getterRef = getAccount(address).capabilities.get<&{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)!
         .borrow()
         ?? panic("CapabilityFactory Getter not found")
     return getterRef.getSupportedTypes()

--- a/scripts/hybrid-custody/borrow_owned_account.cdc
+++ b/scripts/hybrid-custody/borrow_owned_account.cdc
@@ -1,0 +1,11 @@
+import "HybridCustody"
+
+access(all) fun main(owner: Address, child: Address): Address {
+    let m = getAuthAccount<auth(Storage) &Account>(owner).storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+        ?? panic("manager could not be borrowed")
+    let ownedAcct = m.borrowOwnedAccount(addr: child)
+        ?? panic("could not borrow owned account")
+        
+    let acct = ownedAcct.borrowAccount()
+    return acct.address
+}

--- a/scripts/hybrid-custody/check_default_auth_acct_linked_path.cdc
+++ b/scripts/hybrid-custody/check_default_auth_acct_linked_path.cdc
@@ -1,6 +1,0 @@
-import "HybridCustody"
-
-pub fun main(addr: Address): Bool {
-    let acct = getAuthAccount(addr)
-    return acct.getCapability<&AuthAccount>(HybridCustody.LinkedAccountPrivatePath).check()
-}

--- a/scripts/hybrid-custody/get_account_cap_con_id.cdc
+++ b/scripts/hybrid-custody/get_account_cap_con_id.cdc
@@ -1,0 +1,11 @@
+import "HybridCustody"
+
+access(all) fun main(addr: Address): UInt64? {
+    let acct: auth(Capabilities) &Account = getAuthAccount<auth(Capabilities) &Account>(addr)
+    let controllers = acct.capabilities.account.getControllers()
+    if controllers.length == 0 {
+        return nil
+    }
+
+    return controllers[0].capabilityID
+}

--- a/scripts/hybrid-custody/get_account_public_address.cdc
+++ b/scripts/hybrid-custody/get_account_public_address.cdc
@@ -1,0 +1,13 @@
+import "HybridCustody"
+
+access(all) fun main(parent: Address, child: Address): Address {
+    let cap = getAccount(parent).capabilities.get<&{HybridCustody.ManagerPublic}>(HybridCustody.ManagerPublicPath)
+        ?? panic("manager not found")
+    let manager = cap.borrow()
+        ?? panic("unable to borrow manager")
+
+    let acct = manager.borrowAccountPublic(addr: child)
+        ?? panic("child account not found")
+
+    return acct.getAddress()
+}

--- a/scripts/hybrid-custody/get_all_flow_balances.cdc
+++ b/scripts/hybrid-custody/get_all_flow_balances.cdc
@@ -3,7 +3,7 @@ import "HybridCustody"
 
 /// Queries for $FLOW balance of a given Address and all its associated accounts
 ///
-pub fun main(address: Address): {Address: UFix64} {
+access(all) fun main(address: Address): {Address: UFix64} {
 
     // Get the balance for the given address
     let balances: {Address: UFix64} = { address: getAccount(address).balance }
@@ -12,7 +12,7 @@ pub fun main(address: Address): {Address: UFix64} {
     
     /* Iterate over any associated accounts */ 
     //
-    if let managerRef = getAuthAccount(address).borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
+    if let managerRef = getAuthAccount<auth(Storage) &Account>(address).storage.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
         
         for childAccount in managerRef.getChildAddresses() {
             balances.insert(key: childAccount, getAccount(childAccount).balance)

--- a/scripts/hybrid-custody/get_child_account_ft_capabilities.cdc
+++ b/scripts/hybrid-custody/get_child_account_ft_capabilities.cdc
@@ -3,38 +3,41 @@ import "FungibleToken"
 
 // This script iterates through a parent's child accounts, 
 // identifies private paths with an accessible FungibleToken.Provider, and returns the corresponding typeIds
-pub fun main(addr: Address):AnyStruct {
-  let account = getAuthAccount(addr)
-  let manager = getAuthAccount(addr).borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) ?? panic ("manager does not exist")
+access(all) fun main(addr: Address):AnyStruct {
+  let account = getAuthAccount<auth(Storage) &Account>(addr)
+  let manager = getAuthAccount<auth(Storage) &Account>(addr).storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+    ?? panic ("manager does not exist")
 
-  var typeIdsWithProvider = {} as {Address: [String]} 
+  var typeIdsWithProvider: {Address: [String]} = {}
   
-  let providerType = Type<Capability<&{FungibleToken.Provider}>>()
+  let providerType = Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>()
 
   // Iterate through child accounts
   for address in manager.getChildAddresses() {
-    let addr = getAuthAccount(address)
+    let addr = getAuthAccount<auth(Storage, Capabilities) &Account>(address)
     let foundTypes: [String] = []
     let childAcct = manager.borrowAccount(addr: address) ?? panic("child account not found")
     // get all private paths
-    addr.forEachPrivate(fun (path: PrivatePath, type: Type): Bool {
-			// Check which private paths have FT Provider AND can be borrowed
-      if !type.isSubtype(of: providerType){
-        return true
-      }
-      if let cap = childAcct.getCapability(path: path, type: Type<&{FungibleToken.Provider}>()) {
-        let providerCap = cap as! Capability<&{FungibleToken.Provider}> 
 
-        if !providerCap.check(){
-          return true
+    for s in addr.storage.storagePaths {
+      for c in addr.capabilities.storage.getControllers(forPath: s) {
+        if !c.borrowType.isSubtype(of: providerType){
+          continue
         }
+
+        if let cap = childAcct.getCapability(controllerID: c.capabilityID, type: providerType) {
+          let providerCap = cap as! Capability<&{FungibleToken.Provider}> 
+
+          if !providerCap.check(){
+            continue
+          }
 
           foundTypes.append(cap.borrow<&AnyResource>()!.getType().identifier)
+          typeIdsWithProvider[address] = foundTypes
+          break
         }
-        return true
-      })
-
-      typeIdsWithProvider[address] = foundTypes
+      }
+    }      
   }
 
   return typeIdsWithProvider

--- a/scripts/hybrid-custody/get_child_account_nft_capabilities.cdc
+++ b/scripts/hybrid-custody/get_child_account_nft_capabilities.cdc
@@ -3,38 +3,41 @@ import "NonFungibleToken"
 
 // This script iterates through a parent's child accounts, 
 // identifies private paths with an accessible NonFungibleToken.Provider, and returns the corresponding typeIds
-pub fun main(addr: Address):AnyStruct {
-  let account = getAuthAccount(addr)
-  let manager = getAuthAccount(addr).borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) ?? panic ("manager does not exist")
+access(all) fun main(addr: Address): AnyStruct {
+  let account = getAuthAccount<auth(Storage) &Account>(addr)
+  let manager = getAuthAccount<auth(Storage) &Account>(addr).storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) ?? panic ("manager does not exist")
 
-  var typeIdsWithProvider = {} as {Address: [String]} 
+  var typeIdsWithProvider: {Address: [String]} = {}
   
-  let providerType = Type<Capability<&{NonFungibleToken.Provider}>>()
+  let providerType = Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>()
 
   // Iterate through child accounts
   for address in manager.getChildAddresses() {
-    let addr = getAuthAccount(address)
+    let addr = getAuthAccount<auth(Storage, Capabilities) &Account>(address)
     let foundTypes: [String] = []
     let childAcct = manager.borrowAccount(addr: address) ?? panic("child account not found")
     // get all private paths
-    addr.forEachPrivate(fun (path: PrivatePath, type: Type): Bool {
-      // Check which private paths have NFT Provider AND can be borrowed
-      if !type.isSubtype(of: providerType){
-        return true
-      }
-      if let cap = childAcct.getCapability(path: path, type: Type<&{NonFungibleToken.Provider}>()) {
-        let providerCap = cap as! Capability<&{NonFungibleToken.Provider}> 
 
-        if !providerCap.check(){
-          return true
+    for s in addr.storage.storagePaths {
+      let controllers = addr.capabilities.storage.getControllers(forPath: s)
+      for c in controllers {
+        if !c.borrowType.isSubtype(of: providerType) {
+          continue
         }
+
+        if let cap = childAcct.getCapability(controllerID: c.capabilityID, type: providerType) {
+          let providerCap = cap as! Capability<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}> 
+
+          if !providerCap.check(){
+            continue
+          }
 
           foundTypes.append(cap.borrow<&AnyResource>()!.getType().identifier)
+          typeIdsWithProvider[address] = foundTypes
+          break
         }
-        return true
-      })
-
-      typeIdsWithProvider[address] = foundTypes
+      }
+    }
   }
 
   return typeIdsWithProvider

--- a/scripts/hybrid-custody/get_child_addresses.cdc
+++ b/scripts/hybrid-custody/get_child_addresses.cdc
@@ -1,8 +1,8 @@
 import "HybridCustody"
 
-pub fun main(parent: Address): [Address] {
-    let acct = getAuthAccount(parent)
-    let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+access(all) fun main(parent: Address): [Address] {
+    let acct = getAuthAccount<auth(Storage) &Account>(parent)
+    let manager = acct.storage.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
         ?? panic("manager not found")
     return  manager.getChildAddresses()
 }

--- a/scripts/hybrid-custody/get_collection_public_from_child.cdc
+++ b/scripts/hybrid-custody/get_collection_public_from_child.cdc
@@ -1,0 +1,14 @@
+import "HybridCustody"
+import "NonFungibleToken"
+
+access(all) fun main(parent: Address, child: Address, path: PublicPath, type: Type): [UInt64] {
+    let parentAcct = getAuthAccount<auth(Storage) &Account>(parent)
+    let manager = parentAcct.storage.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+        ?? panic("manager not found")
+    let child = manager.borrowAccountPublic(addr: child) ?? panic("child account not found")
+    let cap = child.getPublicCapability(path: path, type: type)
+        ?? panic("could not get capability")
+    let collection = cap.borrow<&{NonFungibleToken.CollectionPublic}>()
+        ?? panic("failed to borrow collection")
+    return collection.getIDs()
+}

--- a/scripts/hybrid-custody/get_examplenft_collection_from_delegator.cdc
+++ b/scripts/hybrid-custody/get_examplenft_collection_from_delegator.cdc
@@ -1,8 +1,9 @@
 import "HybridCustody"
 import "ExampleNFT"
+import "NonFungibleToken"
 
-pub fun main(parent: Address, child: Address, isPublic: Bool) {
-    let m = getAuthAccount(parent).borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+access(all) fun main(parent: Address, child: Address, isPublic: Bool) {
+    let m = getAuthAccount<auth(Storage) &Account>(parent).storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
         ?? panic("manager not found")
     let acct = m.borrowAccount(addr: child)
         ?? panic("child account not found in manager")

--- a/scripts/hybrid-custody/get_ft_provider_capability.cdc
+++ b/scripts/hybrid-custody/get_ft_provider_capability.cdc
@@ -2,16 +2,35 @@ import "HybridCustody"
 
 import "FungibleToken"
 import "ExampleToken"
+import "FungibleTokenMetadataViews"
 
 // Verify that a child address borrowed as a child will let the parent borrow an FT provider capability
-pub fun main(parent: Address, child: Address) {
-    let acct = getAuthAccount(parent)
-    let m = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+access(all) fun main(parent: Address, child: Address) {
+    let acct = getAuthAccount<auth(BorrowValue) &Account>(parent)
+    let m = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
         ?? panic("manager does not exist")
 
     let childAcct = m.borrowAccount(addr: child) ?? panic("child account not found")
-    let nakedCap = childAcct.getCapability(path: /private/exampleTokenProvider, type: Type<&{FungibleToken.Provider}>())
-				?? panic("Could not borrow reference to the owner's Vault!")
+
+    let vaultData = ExampleToken.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>()) as! FungibleTokenMetadataViews.FTVaultData?
+        ?? panic("Could not get the vault data view for ExampleToken")
+
+    // find the et provider
+    var controllerID: UInt64? = nil
+    let desiredType = Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>()
+    let childAuthAcct = getAuthAccount<auth(Capabilities) &Account>(child)
+    for c in childAuthAcct.capabilities.storage.getControllers(forPath: vaultData.storagePath) {
+        if c.borrowType.isSubtype(of: desiredType) {
+            controllerID = c.capabilityID
+            break
+        }
+    }
+
+    assert(controllerID != nil, message: "could not find controller id for FungibleToken Provider")
+
+
+    let nakedCap = childAcct.getCapability(controllerID: controllerID!, type: Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>())
+        ?? panic("Could not borrow reference to the owner's Vault!")
     let providerCap = nakedCap as! Capability<&{FungibleToken.Provider}>
     assert(providerCap.check(), message: "invalid provider capability")
     providerCap.borrow()!

--- a/scripts/hybrid-custody/get_nft_collection_public_capability.cdc
+++ b/scripts/hybrid-custody/get_nft_collection_public_capability.cdc
@@ -5,16 +5,19 @@ import "MetadataViews"
 import "ExampleNFT"
 
 // Verify that a child address borrowed as a child will let the parent borrow an NFT provider capability
-pub fun main(parent: Address, child: Address) {
-    let acct = getAuthAccount(parent)
-    let m = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+access(all) fun main(parent: Address, child: Address) {
+    let acct = getAuthAccount<auth(Storage) &Account>(parent)
+    let m = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
         ?? panic("manager does not exist")
 
     let childAcct = m.borrowAccount(addr: child) ?? panic("child account not found")
 
-    let d = ExampleNFT.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
+    let d = ExampleNFT.resolveContractView(resourceType: nil, viewType: Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
+    let type = Type<&{NonFungibleToken.CollectionPublic}>()
+    let controllerId = childAcct.getControllerIDForType(type: type, forPath: d.storagePath)
+        ?? panic("no controller ID found for desired type")
 
-    let nakedCap = childAcct.getCapability(path: d.providerPath, type: Type<&{NonFungibleToken.CollectionPublic}>())
+    let nakedCap = childAcct.getCapability(controllerID: controllerId, type: type)
         ?? panic("capability not found")
 
     let cap = nakedCap as! Capability<&{NonFungibleToken.CollectionPublic}>

--- a/scripts/hybrid-custody/get_nft_provider_capability.cdc
+++ b/scripts/hybrid-custody/get_nft_provider_capability.cdc
@@ -5,16 +5,20 @@ import "MetadataViews"
 import "ExampleNFT"
 
 // Verify that a child address borrowed as a child will let the parent borrow an NFT provider capability
-pub fun main(parent: Address, child: Address) {
-    let acct = getAuthAccount(parent)
-    let m = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+access(all) fun main(parent: Address, child: Address) {
+    let acct = getAuthAccount<auth(Storage) &Account>(parent)
+    let m = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
         ?? panic("manager does not exist")
 
     let childAcct = m.borrowAccount(addr: child) ?? panic("child account not found")
 
-    let d = ExampleNFT.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
+    let d = ExampleNFT.resolveContractView(resourceType: nil, viewType: Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
 
-    let nakedCap = childAcct.getCapability(path: d.providerPath, type: Type<&{NonFungibleToken.Provider}>())
+    let desiredType = Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>()
+    let controllerID = childAcct.getControllerIDForType(type: desiredType, forPath: d.storagePath)
+        ?? panic("no capability found for desired type")
+
+    let nakedCap = childAcct.getCapability(controllerID: controllerID, type: desiredType)
         ?? panic("capability not found")
 
     let cap = nakedCap as! Capability<&{NonFungibleToken.Provider}>

--- a/scripts/hybrid-custody/get_num_valid_keys.cdc
+++ b/scripts/hybrid-custody/get_num_valid_keys.cdc
@@ -1,5 +1,5 @@
-pub fun main(addr: Address): Int {
-    let acct = getAuthAccount(addr)
+access(all) fun main(addr: Address): Int {
+    let acct = getAuthAccount<auth(Keys) &Account>(addr)
     var count = 0
 
     acct.keys.forEach(fun (key: AccountKey): Bool {

--- a/scripts/hybrid-custody/get_owner_of_child.cdc
+++ b/scripts/hybrid-custody/get_owner_of_child.cdc
@@ -1,8 +1,8 @@
 import "HybridCustody"
 
-pub fun main(addr: Address): Address? {
-    let acct = getAuthAccount(addr)
-    let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+access(all) fun main(addr: Address): Address? {
+    let acct = getAuthAccount<auth(Storage) &Account>(addr)
+    let o = acct.storage.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
         ?? panic("owned account missing")
     
     return o.getOwner()

--- a/scripts/hybrid-custody/get_parent_addresses.cdc
+++ b/scripts/hybrid-custody/get_parent_addresses.cdc
@@ -1,8 +1,8 @@
 import "HybridCustody"
 
-pub fun main(child: Address): [Address] {
-    let acct = getAuthAccount(child)
-    let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+access(all) fun main(child: Address): [Address] {
+    let acct = getAuthAccount<auth(Storage) &Account>(child)
+    let o = acct.storage.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
         ?? panic("owned account not found")
     return  o.getParentAddresses() 
 }

--- a/scripts/hybrid-custody/get_pending_owner_of_child.cdc
+++ b/scripts/hybrid-custody/get_pending_owner_of_child.cdc
@@ -1,8 +1,8 @@
 import "HybridCustody"
 
-pub fun main(addr: Address): Address? {
-    let acct = getAuthAccount(addr)
-    let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+access(all) fun main(addr: Address): Address? {
+    let acct = getAuthAccount<auth(BorrowValue) &Account>(addr)
+    let o = acct.storage.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
         ?? panic("owned account missing")
     
     return o.getPendingOwner()

--- a/scripts/hybrid-custody/get_spec_balance_from_public.cdc
+++ b/scripts/hybrid-custody/get_spec_balance_from_public.cdc
@@ -3,13 +3,18 @@ import "HybridCustody"
 
 /// Returns the balance of the object (presumably a FungibleToken Vault) at the given path in the specified account
 ///
-pub fun getVaultBalance(_ address: Address, _ balancePath: PublicPath): UFix64 {
-    return getAccount(address).getCapability<&{FungibleToken.Balance}>(balancePath).borrow()?.balance ?? 0.0
+access(all) fun getVaultBalance(_ address: Address, _ balancePath: PublicPath): UFix64 {
+    let cap = getAccount(address).capabilities.get<&{FungibleToken.Balance}>(balancePath)
+    if cap == nil {
+        return 0.0
+    }
+
+    return cap!.borrow()?.balance ?? 0.0
 }
 
 /// Queries for FT.Vault balance of all FT.Vaults at given path in the specified account and all of its associated accounts
 ///
-pub fun main(address: Address, balancePath: PublicPath): {Address: UFix64} {
+access(all) fun main(address: Address, balancePath: PublicPath): {Address: UFix64} {
 
     // Get the balance for the given address
     let balances: {Address: UFix64} = { address: getVaultBalance(address, balancePath) }
@@ -18,7 +23,7 @@ pub fun main(address: Address, balancePath: PublicPath): {Address: UFix64} {
     
     /* Iterate over any associated accounts */ 
     //
-    if let managerRef = getAuthAccount(address).borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
+    if let managerRef = getAuthAccount<auth(Storage) &Account>(address).storage.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
         
         for childAccount in managerRef.getChildAddresses() {
             balances.insert(key: childAccount, getVaultBalance(address, balancePath))

--- a/scripts/hybrid-custody/has_address_as_child.cdc
+++ b/scripts/hybrid-custody/has_address_as_child.cdc
@@ -1,8 +1,8 @@
 import "HybridCustody"
 
-pub fun main(parent: Address, child: Address): Bool {
-    let acct = getAuthAccount(parent)
-    let m = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+access(all) fun main(parent: Address, child: Address): Bool {
+    let acct = getAuthAccount<auth(Storage) &Account>(parent)
+    let m = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
         ?? panic("manager not found")
 
     let childAccount = m.borrowAccount(addr: child)

--- a/scripts/hybrid-custody/has_child_accounts.cdc
+++ b/scripts/hybrid-custody/has_child_accounts.cdc
@@ -2,9 +2,9 @@ import "HybridCustody"
 
 /// Returns whether the given Address has a HybridCustod.Manager with child accounts or not
 ///
-pub fun main(parent: Address): Bool {
-    let acct = getAuthAccount(parent)
-    if let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
+access(all) fun main(parent: Address): Bool {
+    let acct = getAuthAccount<auth(BorrowValue) &Account>(parent)
+    if let manager = acct.storage.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
         return manager.getChildAddresses().length > 0
     }
     return false

--- a/scripts/hybrid-custody/has_owned_accounts.cdc
+++ b/scripts/hybrid-custody/has_owned_accounts.cdc
@@ -2,9 +2,9 @@ import "HybridCustody"
 
 /// Returns whether the given Address has a HybridCustod.Manager with owned accounts or not
 ///
-pub fun main(parent: Address): Bool {
-    let acct = getAuthAccount(parent)
-    if let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
+access(all) fun main(parent: Address): Bool {
+    let acct = getAuthAccount<auth(Storage) &Account>(parent)
+    if let manager = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
         return manager.getOwnedAddresses().length > 0
     }
     return false

--- a/scripts/hybrid-custody/is_parent.cdc
+++ b/scripts/hybrid-custody/is_parent.cdc
@@ -1,8 +1,8 @@
 import "HybridCustody"
 
-pub fun main(child: Address, parent: Address): Bool {
-    let acct = getAuthAccount(child)
-    let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+access(all) fun main(child: Address, parent: Address): Bool {
+    let acct = getAuthAccount<auth(Storage) &Account>(child)
+    let owned = acct.storage.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
         ?? panic("owned account not found")
 
     return owned.isChildOf(parent)

--- a/scripts/hybrid-custody/is_redeemed.cdc
+++ b/scripts/hybrid-custody/is_redeemed.cdc
@@ -1,8 +1,8 @@
 import "HybridCustody"
 
-pub fun main(child: Address, parent: Address): Bool {
-    let acct = getAuthAccount(child)
-    let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+access(all) fun main(child: Address, parent: Address): Bool {
+    let acct = getAuthAccount<auth(Storage) &Account>(child)
+    let owned = acct.storage.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
         ?? panic("owned account not found")
 
     return owned.getRedeemedStatus(addr: parent) ?? panic("no status found")

--- a/scripts/hybrid-custody/metadata/assert_owned_account_display.cdc
+++ b/scripts/hybrid-custody/metadata/assert_owned_account_display.cdc
@@ -1,9 +1,9 @@
 import "HybridCustody"
 import "MetadataViews"
 
-pub fun main(addr: Address, name: String, desc: String, thumbnail: String): Bool {
-    let acct = getAuthAccount(addr)
-    let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+access(all) fun main(addr: Address, name: String, desc: String, thumbnail: String): Bool {
+    let acct = getAuthAccount<auth(Storage) &Account>(addr)
+    let owned = acct.storage.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
         ?? panic("no owned account found")
     let display = owned.resolveView(Type<MetadataViews.Display>())! as! MetadataViews.Display
 

--- a/scripts/hybrid-custody/metadata/resolve_child_display_name.cdc
+++ b/scripts/hybrid-custody/metadata/resolve_child_display_name.cdc
@@ -1,9 +1,9 @@
 import "HybridCustody"
 import "MetadataViews"
 
-pub fun main(parent: Address, child: Address): String {
-    let acct = getAuthAccount(parent)
-    let m = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+access(all) fun main(parent: Address, child: Address): String {
+    let acct = getAuthAccount<auth(Storage) &Account>(parent)
+    let m = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager not found")
 
     let c = m.borrowAccount(addr: child) ?? panic("child not found")

--- a/scripts/hybrid-custody/metadata/resolve_child_display_name.cdc
+++ b/scripts/hybrid-custody/metadata/resolve_child_display_name.cdc
@@ -7,7 +7,9 @@ access(all) fun main(parent: Address, child: Address): String {
             ?? panic("manager not found")
 
     let c = m.borrowAccount(addr: child) ?? panic("child not found")
+
+    let tmp = c.resolveView(Type<MetadataViews.Display>()) ?? panic("unable to resolve metadata display")
     
-    let d = c.resolveView(Type<MetadataViews.Display>())! as! MetadataViews.Display
+    let d = tmp as! MetadataViews.Display
     return d.name
 }

--- a/scripts/hybrid-custody/metadata/resolve_owned_display_name.cdc
+++ b/scripts/hybrid-custody/metadata/resolve_owned_display_name.cdc
@@ -1,9 +1,9 @@
 import "HybridCustody"
 import "MetadataViews"
 
-pub fun main(child: Address): String {
-    let acct = getAuthAccount(child)
-    let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+access(all) fun main(child: Address): String {
+    let acct = getAuthAccount<auth(Storage) &Account>(child)
+    let o = acct.storage.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("owned account not found")
     
     let d = o.resolveView(Type<MetadataViews.Display>())! as! MetadataViews.Display

--- a/scripts/hybrid-custody/verify_child_address.cdc
+++ b/scripts/hybrid-custody/verify_child_address.cdc
@@ -4,9 +4,9 @@ import "HybridCustody"
 Verify that a owned address borrowed as a child matches the address
 it is mapped to in the account manager
 */
-pub fun main(parent: Address, child: Address) {
-    let acct = getAuthAccount(parent)
-    let m = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+access(all) fun main(parent: Address, child: Address) {
+    let acct = getAuthAccount<auth(BorrowValue) &Account>(parent)
+    let m = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
         ?? panic("manager does not exist")
 
     let childAcct = m.borrowAccount(addr: child) ?? panic("child account not found")

--- a/scripts/test/add_type_for_nft_provider_factory.cdc
+++ b/scripts/test/add_type_for_nft_provider_factory.cdc
@@ -3,8 +3,8 @@ import "NFTProviderFactory"
 
 import "NonFungibleToken"
 
-pub fun main(address: Address, type: Type): Bool {
-    let managerRef = getAuthAccount(address).borrow<&CapabilityFactory.Manager>(
+access(all) fun main(address: Address, type: Type): Bool {
+    let managerRef = getAuthAccount<auth(Storage) &Account>(address).storage.borrow<auth(Mutate) &CapabilityFactory.Manager>(
         from: CapabilityFactory.StoragePath
     ) ?? panic("CapabilityFactory Manager not found")
     

--- a/scripts/test/create_manager_with_invalid_filter.cdc
+++ b/scripts/test/create_manager_with_invalid_filter.cdc
@@ -1,9 +1,13 @@
 import "CapabilityFilter"
 import "HybridCustody"
 
-pub fun main(address: Address): Bool {
+access(all) fun main(address: Address): Bool {
+    let acct = getAuthAccount<auth(Capabilities, Storage) &Account>(address)
     // Retrieving invalid Filter capability
-    let invalidFilterCap = getAuthAccount(address).getCapability<&{CapabilityFilter.Filter}>(CapabilityFilter.PrivatePath)
+    let invalidFilterCap = acct.capabilities.storage.issue<&{CapabilityFilter.Filter}>(CapabilityFilter.StoragePath)
+
+    acct.capabilities.storage.getController(byCapabilityID: invalidFilterCap.id)!.delete()
+
     // This step should fail due to CapabilityFilter.Filter Capability check on Manager init
     let manager <- HybridCustody.createManager(filter: invalidFilterCap)
     // Destroy and return

--- a/scripts/test/get_flow_balance.cdc
+++ b/scripts/test/get_flow_balance.cdc
@@ -1,3 +1,3 @@
-pub fun main(address: Address): UFix64 {
+access(all) fun main(address: Address): UFix64 {
     return getAccount(address).balance
 }

--- a/scripts/test/get_nft_provider_capability_optional.cdc
+++ b/scripts/test/get_nft_provider_capability_optional.cdc
@@ -5,16 +5,20 @@ import "MetadataViews"
 import "ExampleNFT"
 
 // Verify that a child address borrowed as a child will let the parent borrow an NFT provider capability
-pub fun main(parent: Address, child: Address, returnsNil: Bool): Bool {
-    let acct = getAuthAccount(parent)
-    let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+access(all) fun main(parent: Address, child: Address, returnsNil: Bool): Bool {
+    let acct = getAuthAccount<auth(Storage) &Account>(parent)
+    let manager = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
         ?? panic("manager does not exist")
 
     let childAcct = manager.borrowAccount(addr: child) ?? panic("child account not found")
 
-    let collectionData = ExampleNFT.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
+    let collectionData = ExampleNFT.resolveContractView(resourceType: nil, viewType: Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
 
-    let nakedCap = childAcct.getCapability(path: collectionData.providerPath, type: Type<&{NonFungibleToken.Provider}>())
+    let type = Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>()
+    let controllerID = childAcct.getControllerIDForType(type: type, forPath: collectionData.storagePath)
+        ?? panic("could not find controller for desired type")
+
+    let nakedCap = childAcct.getCapability(controllerID: controllerID, type: type)
 
     return returnsNil ? nakedCap == nil : nakedCap?.borrow<&{NonFungibleToken.Provider}>() != nil
 }

--- a/scripts/test/get_type_from_factory.cdc
+++ b/scripts/test/get_type_from_factory.cdc
@@ -2,8 +2,8 @@ import "NonFungibleToken"
 
 import "CapabilityFactory"
 
-pub fun main(address: Address, type: Type): Bool {
-    let managerRef = getAuthAccount(address).borrow<&CapabilityFactory.Manager>(
+access(all) fun main(address: Address, type: Type): Bool {
+    let managerRef = getAuthAccount<auth(Storage) &Account>(address).storage.borrow<&CapabilityFactory.Manager>(
         from: CapabilityFactory.StoragePath
     ) ?? panic("CapabilityFactory Manager not found")
 

--- a/scripts/test/remove_nft_provider_factory.cdc
+++ b/scripts/test/remove_nft_provider_factory.cdc
@@ -3,14 +3,14 @@ import "NFTProviderFactory"
 
 import "NonFungibleToken"
 
-pub fun main(address: Address): Bool {
+access(all) fun main(address: Address): Bool {
     
-    let managerRef = getAuthAccount(address).borrow<&CapabilityFactory.Manager>(from: CapabilityFactory.StoragePath)
+    let managerRef = getAuthAccount<auth(Storage) &Account>(address).storage.borrow<auth(Mutate) &CapabilityFactory.Manager>(from: CapabilityFactory.StoragePath)
         ?? panic("CapabilityFactory Manager not found")
     
     let expectedType = Type<NFTProviderFactory.Factory>()
     
-    if let removed = managerRef.removeFactory(Type<&{NonFungibleToken.Provider}>()) {
+    if let removed = managerRef.removeFactory(Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>()) {
         return removed.getType() == expectedType
     }
 

--- a/scripts/test/test_get_accessible_child_nfts.cdc
+++ b/scripts/test/test_get_accessible_child_nfts.cdc
@@ -10,7 +10,7 @@ import "MetadataViews"
 
 /// Assertion method to ensure passing test
 ///
-pub fun assertPassing(result: {Address: {UInt64: MetadataViews.Display}}, expectedAddressToIDs: {Address: [UInt64]}) {
+access(all) fun assertPassing(result: {Address: {UInt64: MetadataViews.Display}}, expectedAddressToIDs: {Address: [UInt64]}) {
   for address in expectedAddressToIDs.keys {
     let expectedIDs: [UInt64] = expectedAddressToIDs[address]!
 
@@ -22,42 +22,44 @@ pub fun assertPassing(result: {Address: {UInt64: MetadataViews.Display}}, expect
   }
 }
 
-pub fun main(addr: Address, expectedAddressToIDs: {Address: [UInt64]}){
-  let manager = getAuthAccount(addr).borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) ?? panic ("manager does not exist")
+access(all) fun main(addr: Address, expectedAddressToIDs: {Address: [UInt64]}){
+  let manager = getAuthAccount<auth(Storage) &Account>(addr).storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+    ?? panic ("manager does not exist")
 
-  var typeIdsWithProvider = {} as {Address: [String]} 
-  var nftViews = {} as {Address: {UInt64: MetadataViews.Display}} 
+  var typeIdsWithProvider: {Address: [String]} = {}
+  var nftViews: {Address: {UInt64: MetadataViews.Display}} = {}
 
-  let providerType = Type<Capability<&{NonFungibleToken.Provider}>>()
+  let providerType = Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>()
   let collectionType: Type = Type<@{NonFungibleToken.CollectionPublic}>()
 
   for address in manager.getChildAddresses() {
-    let acct = getAuthAccount(address)
+    let acct = getAuthAccount<auth(Storage, Capabilities) &Account>(address)
     let foundTypes: [String] = []
     let views: {UInt64: MetadataViews.Display} = {}
     let childAcct = manager.borrowAccount(addr: address) ?? panic("child account not found")
-    // get all private paths
-    acct.forEachPrivate(fun (path: PrivatePath, type: Type): Bool {
-      // Check which private paths have NFT Provider AND can be borrowed
-      if !type.isSubtype(of: providerType){
-        return true
-      }
 
-      if let cap: Capability = childAcct.getCapability(path: path, type: Type<&{NonFungibleToken.Provider}>()) {
-        let providerCap = cap as! Capability<&{NonFungibleToken.Provider}> 
-
-        if !providerCap.check(){
-          return true
+    for s in acct.storage.storagePaths {
+      for c in acct.capabilities.storage.getControllers(forPath: s) {
+        if !c.borrowType.isSubtype(of: providerType){
+          continue
         }
 
-        foundTypes.append(cap.borrow<&AnyResource>()!.getType().identifier)
+        if let cap: Capability = childAcct.getCapability(controllerID: c.capabilityID, type: providerType) {
+          let providerCap = cap as! Capability<&{NonFungibleToken.Provider}> 
+
+          if !providerCap.check(){
+            continue
+          }
+
+          foundTypes.append(cap.borrow<&AnyResource>()!.getType().identifier)
+          typeIdsWithProvider[address] = foundTypes
+          break
+        }
       }
-      return true
-    })
-    typeIdsWithProvider[address] = foundTypes
+    }
 
     // iterate storage, check if typeIdsWithProvider contains the typeId, if so, add to views
-    acct.forEachStored(fun (path: StoragePath, type: Type): Bool {
+    acct.storage.forEachStored(fun (path: StoragePath, type: Type): Bool {
 
       if typeIdsWithProvider[address] == nil {
         return true
@@ -73,10 +75,10 @@ pub fun main(addr: Address, expectedAddressToIDs: {Address: [UInt64]}){
             if type.isInstance(collectionType) {
               continue
             }
-            if let collection = acct.borrow<&{NonFungibleToken.CollectionPublic}>(from: path) { 
+            if let collection = acct.storage.borrow<&{NonFungibleToken.CollectionPublic}>(from: path) { 
               // Iterate over IDs & resolve the view
               for id in collection.getIDs() {
-                let nft = collection.borrowNFT(id: id)
+                let nft = collection.borrowNFT(id)!
                 if let display = nft.resolveView(Type<MetadataViews.Display>())! as? MetadataViews.Display {
                   views.insert(key: id, display)
                 }

--- a/scripts/test/update_nft_provider_factory.cdc
+++ b/scripts/test/update_nft_provider_factory.cdc
@@ -3,9 +3,8 @@ import "NFTProviderFactory"
 
 import "NonFungibleToken"
 
-pub fun main(address: Address) {
-    
-    let managerRef = getAuthAccount(address).borrow<&CapabilityFactory.Manager>(from: CapabilityFactory.StoragePath)
+access(all) fun main(address: Address) {
+    let managerRef = getAuthAccount<auth(Storage) &Account>(address).storage.borrow<auth(Mutate) &CapabilityFactory.Manager>(from: CapabilityFactory.StoragePath)
         ?? panic("CapabilityFactory Manager not found")
     
     let nftProviderFactory = NFTProviderFactory.Factory()

--- a/scripts/test_imports.cdc
+++ b/scripts/test_imports.cdc
@@ -1,5 +1,5 @@
 import "HybridCustody"
 
-pub fun main(): Bool {
+access(all) fun main(): Bool {
     return true
 }

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-flow test --cover --covercode="contracts" --coverprofile="coverage.lcov" test/*_tests.cdc
+flow-c1 test --cover --covercode="contracts" --coverprofile="coverage.lcov" test/*_tests.cdc

--- a/test/CapabilityDelegator_tests.cdc
+++ b/test/CapabilityDelegator_tests.cdc
@@ -37,12 +37,12 @@ fun testShareExampleNFTCollectionPublic() {
     let events = Test.eventsOfType(typ)
     Test.assertEqual(1, events.length)
 
-    let event = events[0]! as! CapabilityDelegator.DelegatorUpdated
-    Test.assert(event.isPublic)
-    Test.assert(event.active)
+    let e = events[0] as! CapabilityDelegator.DelegatorUpdated
+    Test.assert(e.isPublic)
+    Test.assert(e.active)
 
-    let capabilityType = Type<Capability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>>()
-    Test.assertEqual(capabilityType, event.capabilityType)
+    let capabilityType = Type<Capability<&{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>>()
+    Test.assertEqual(capabilityType, e.capabilityType)
 }
 
 access(all)
@@ -56,12 +56,12 @@ fun testShareExampleNFTCollectionPrivate() {
     let events = Test.eventsOfType(typ)
     Test.assertEqual(2, events.length)
 
-    let event = events[1]! as! CapabilityDelegator.DelegatorUpdated
-    Test.assert(event.isPublic == false)
-    Test.assert(event.active)
+    let e = events[1] as! CapabilityDelegator.DelegatorUpdated
+    Test.assert(e.isPublic == false)
+    Test.assert(e.active)
 
-    let capabilityType = Type<Capability<&ExampleNFT.Collection{NonFungibleToken.Provider}>>()
-    Test.assertEqual(capabilityType, event.capabilityType)
+    let capabilityType = Type<Capability<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>>()
+    Test.assertEqual(capabilityType, e.capabilityType)
 }
 
 access(all)
@@ -72,12 +72,12 @@ fun testRemoveExampleNFTCollectionPublic() {
     let events = Test.eventsOfType(typ)
     Test.assertEqual(3, events.length)
 
-    let event = events[2]! as! CapabilityDelegator.DelegatorUpdated
-    Test.assert(event.isPublic)
-    Test.assert(event.active == false)
+    let e = events[2] as! CapabilityDelegator.DelegatorUpdated
+    Test.assert(e.isPublic)
+    Test.assert(e.active == false)
 
-    let capabilityType = Type<Capability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>>()
-    Test.assertEqual(capabilityType, event.capabilityType)
+    let capabilityType = Type<Capability<&{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>>()
+    Test.assertEqual(capabilityType, e.capabilityType)
 
     let scriptCode = loadCode("delegator/find_nft_collection_cap.cdc", "scripts")
     let scriptResult = Test.executeScript(scriptCode, [creator.address])
@@ -97,12 +97,12 @@ fun testRemoveExampleNFTCollectionPrivate() {
     let events = Test.eventsOfType(typ)
     Test.assertEqual(4, events.length)
 
-    let event = events[3]! as! CapabilityDelegator.DelegatorUpdated
-    Test.assert(event.isPublic == false)
-    Test.assert(event.active == false)
+    let e = events[3] as! CapabilityDelegator.DelegatorUpdated
+    Test.assert(e.isPublic == false)
+    Test.assert(e.active == false)
 
-    let capabilityType = Type<Capability<&ExampleNFT.Collection{NonFungibleToken.Provider}>>()
-    Test.assertEqual(capabilityType, event.capabilityType)
+    let capabilityType = Type<Capability<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>>()
+    Test.assertEqual(capabilityType, e.capabilityType)
 
     let scriptCode = loadCode("delegator/find_nft_provider_cap.cdc", "scripts")
     let scriptResult = Test.executeScript(scriptCode, [creator.address])
@@ -119,7 +119,7 @@ fun testRemoveExampleNFTCollectionPrivate() {
 access(all)
 fun setup() {
     // helper nft contract so we can actually talk to nfts with tests
-    deploy("ExampleNFT", "../modules/flow-nft/contracts/ExampleNFT.cdc")
+    deploy("ExampleNFT", "../contracts/standard/ExampleNFT.cdc")
 
     // our main contract is last
     deploy("CapabilityDelegator", "../contracts/CapabilityDelegator.cdc")
@@ -129,42 +129,42 @@ fun setup() {
 
 // BEGIN SECTION - transactions used in tests
 access(all)
-fun setupDelegator(_ acct: Test.Account) {
+fun setupDelegator(_ acct: Test.TestAccount) {
     txExecutor("delegator/setup.cdc", [acct], [], nil)
 }
 
 access(all)
-fun sharePublicExampleNFT(_ acct: Test.Account) {
+fun sharePublicExampleNFT(_ acct: Test.TestAccount) {
     txExecutor("delegator/add_public_nft_collection.cdc", [acct], [], nil)
 }
 
 access(all)
-fun sharePrivateExampleNFT(_ acct: Test.Account) {
+fun sharePrivateExampleNFT(_ acct: Test.TestAccount) {
     txExecutor("delegator/add_private_nft_collection.cdc", [acct], [], nil)
 }
 
 access(all)
-fun removePublicExampleNFT(_ acct: Test.Account) {
+fun removePublicExampleNFT(_ acct: Test.TestAccount) {
     txExecutor("delegator/remove_public_nft_collection.cdc", [acct], [], nil)
 }
 
 access(all)
-fun removePrivateExampleNFT(_ acct: Test.Account) {
+fun removePrivateExampleNFT(_ acct: Test.TestAccount) {
     txExecutor("delegator/remove_private_nft_collection.cdc", [acct], [], nil)
 }
 
 access(all)
-fun setupNFTCollection(_ acct: Test.Account) {
+fun setupNFTCollection(_ acct: Test.TestAccount) {
     txExecutor("example-nft/setup_full.cdc", [acct], [], nil)
 }
 
 access(all)
-fun mintNFT(_ minter: Test.Account, receiver: Test.Account, name: String, description: String, thumbnail: String) {
+fun mintNFT(_ minter: Test.TestAccount, receiver: Test.TestAccount, name: String, description: String, thumbnail: String) {
     txExecutor("example-nft/mint_to_account.cdc", [minter], [receiver.address, name, description, thumbnail], nil)
 }
 
 access(all)
-fun mintNFTDefault(_ minter: Test.Account, receiver: Test.Account) {
+fun mintNFTDefault(_ minter: Test.TestAccount, receiver: Test.TestAccount) {
     return mintNFT(minter, receiver: receiver, name: "example nft", description: "lorem ipsum", thumbnail: flowtyThumbnail)
 }
 
@@ -173,37 +173,37 @@ fun mintNFTDefault(_ minter: Test.Account, receiver: Test.Account) {
 // BEGIN SECTION - scripts used in tests
 
 access(all)
-fun getExampleNFTCollectionFromDelegator(_ owner: Test.Account) {
+fun getExampleNFTCollectionFromDelegator(_ owner: Test.TestAccount) {
     let borrowed = scriptExecutor("delegator/get_nft_collection.cdc", [owner.address])! as! Bool
     Test.assert(borrowed, message: "failed to borrow delegator")
 }
 
 access(all)
-fun getExampleNFTProviderFromDelegator(_ owner: Test.Account) {
+fun getExampleNFTProviderFromDelegator(_ owner: Test.TestAccount) {
     let borrowed = scriptExecutor("delegator/get_nft_provider.cdc", [owner.address])! as! Bool
     Test.assert(borrowed, message: "failed to borrow delegator")
 }
 
 access(all)
-fun getAllPublicContainsCollection(_ owner: Test.Account) {
+fun getAllPublicContainsCollection(_ owner: Test.TestAccount) {
     let success = scriptExecutor("delegator/get_all_public_caps.cdc", [owner.address])! as! Bool
     Test.assert(success, message: "failed to borrow delegator")
 }
 
 access(all)
-fun getAllPrivateContainsProvider(_ owner: Test.Account) {
+fun getAllPrivateContainsProvider(_ owner: Test.TestAccount) {
     let success = scriptExecutor("delegator/get_all_private_caps.cdc", [owner.address])! as! Bool
     Test.assert(success, message: "failed to borrow delegator")
 }
 
 access(all)
-fun findExampleNFTCollectionType(_ owner: Test.Account) {
+fun findExampleNFTCollectionType(_ owner: Test.TestAccount) {
     let borrowed = scriptExecutor("delegator/find_nft_collection_cap.cdc", [owner.address])! as! Bool
     Test.assert(borrowed, message: "failed to borrow delegator")
 }
 
 access(all)
-fun findExampleNFTProviderType(_ owner: Test.Account) {
+fun findExampleNFTProviderType(_ owner: Test.TestAccount) {
     let borrowed = scriptExecutor("delegator/find_nft_provider_cap.cdc", [owner.address])! as! Bool
     Test.assert(borrowed, message: "failed to borrow delegator")
 }

--- a/test/CapabilityFactory_tests.cdc
+++ b/test/CapabilityFactory_tests.cdc
@@ -207,12 +207,12 @@ fun setup() {
 // BEGIN SECTION - transactions used in tests
 
 access(all)
-fun setupNFTCollection(_ acct: Test.Account) {
+fun setupNFTCollection(_ acct: Test.TestAccount) {
     txExecutor("example-nft/setup_full.cdc", [acct], [], nil)
 }
 
 access(all)
-fun setupCapabilityFactoryManager(_ acct: Test.Account) {
+fun setupCapabilityFactoryManager(_ acct: Test.TestAccount) {
     txExecutor("factory/setup_nft_ft_manager.cdc", [acct], [], nil)
 }
 

--- a/test/CapabilityFactory_tests.cdc
+++ b/test/CapabilityFactory_tests.cdc
@@ -33,23 +33,25 @@ fun testGetSupportedTypesFromManager() {
     )! as! [Type]
 
     let expectedTypes = [
-        Type<&{FungibleToken.Provider}>(),
+        Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>(),
         Type<&{FungibleToken.Balance}>(),
         Type<&{FungibleToken.Receiver}>(),
         Type<&{FungibleToken.Receiver, FungibleToken.Balance}>(),
-        Type<&{FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance}>(),
-        Type<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(),
+        Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance}>(),
+        Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(),
         Type<&{NonFungibleToken.CollectionPublic}>(),
-        Type<&{NonFungibleToken.Provider}>()
+        Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>()
     ]
-    Test.assertEqual(expectedTypes, supportedTypes)
+    for e in expectedTypes {
+        Test.assert(supportedTypes.contains(e), message: "missing expected type in supported types")
+    }
 }
 
 access(all)
 fun testAddFactoryFails() {
     expectScriptFailure(
         "test/add_type_for_nft_provider_factory.cdc",
-        [creator.address, Type<&{NonFungibleToken.Provider}>()],
+        [creator.address, Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>()],
         "Factory of given type already exists"
     )
 }
@@ -64,17 +66,20 @@ fun testAddFactorySucceeds() {
     )! as! [Type]
 
     let expectedTypes = [
-        Type<&{FungibleToken.Provider}>(),
+        Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>(),
         Type<&{FungibleToken.Balance}>(),
         Type<&{FungibleToken.Receiver}>(),
         Type<&{FungibleToken.Receiver, FungibleToken.Balance}>(),
-        Type<&{FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance}>(),
-        Type<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(),
+        Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance}>(),
+        Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(),
         Type<&{NonFungibleToken.CollectionPublic}>(),
-        Type<&{NonFungibleToken.Provider}>(),
+        Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>(),
         Type<&{NonFungibleToken.Receiver}>()
     ]
-    Test.assertEqual(expectedTypes, supportedTypes)
+
+    for e in expectedTypes {
+        Test.assert(supportedTypes.contains(e), message: "missing expected type in supportedTypes")
+    }
 
     for type in supportedTypes {
         let factorySuccess = scriptExecutor(
@@ -116,11 +121,14 @@ fun testSetupNFTManager() {
     let supportedTypes = scriptExecutor("factory/get_supported_types_from_manager.cdc", [tmp.address])! as! [Type]
 
     let expectedTypes = [
-        Type<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(),
+        Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(),
         Type<&{NonFungibleToken.CollectionPublic}>(),
-        Type<&{NonFungibleToken.Provider}>()
+        Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>()
     ]
-    Test.assertEqual(expectedTypes, supportedTypes)
+    
+    for e in expectedTypes {
+        Test.assert(supportedTypes.contains(e), message: "missing type in supportedTypes: ".concat(e.identifier))
+    }
 
     for type in supportedTypes {
         let factorySuccess = scriptExecutor(
@@ -139,13 +147,16 @@ fun testSetupFTManager() {
     let supportedTypes = scriptExecutor("factory/get_supported_types_from_manager.cdc", [tmp.address])! as! [Type]
 
     let expectedTypes = [
-        Type<&{FungibleToken.Provider}>(),
+        Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>(),
         Type<&{FungibleToken.Balance}>(),
         Type<&{FungibleToken.Receiver}>(),
         Type<&{FungibleToken.Receiver, FungibleToken.Balance}>(),
-        Type<&{FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance}>()
+        Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance}>()
     ]
-    Test.assertEqual(expectedTypes, supportedTypes)
+
+    for e in expectedTypes {
+        Test.assert(supportedTypes.contains(e), message: "missing type in supportedTypes: ".concat(e.identifier))
+    }
 
     for type in supportedTypes {
         let factorySuccess = scriptExecutor(
@@ -164,16 +175,19 @@ fun testSetupNFTFTManager() {
     let supportedTypes = scriptExecutor("factory/get_supported_types_from_manager.cdc", [tmp.address])! as! [Type]
 
     let expectedTypes = [
-        Type<&{FungibleToken.Provider}>(),
+        Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>(),
         Type<&{FungibleToken.Balance}>(),
         Type<&{FungibleToken.Receiver}>(),
         Type<&{FungibleToken.Receiver, FungibleToken.Balance}>(),
-        Type<&{FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance}>(),
-        Type<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(),
+        Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance}>(),
+        Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(),
         Type<&{NonFungibleToken.CollectionPublic}>(),
-        Type<&{NonFungibleToken.Provider}>()
+        Type<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>()
     ]
-    Test.assertEqual(expectedTypes, supportedTypes)
+
+    for e in expectedTypes {
+        Test.assert(supportedTypes.contains(e), message: "missing type in supportedTypes: ".concat(e.identifier))
+    }
 
     for type in supportedTypes {
         let factorySuccess = scriptExecutor(
@@ -189,7 +203,7 @@ fun testSetupNFTFTManager() {
 access(all)
 fun setup() {
     // helper nft & ft contract so we can actually talk to nfts & fts with tests
-    deploy("ExampleNFT", "../modules/flow-nft/contracts/ExampleNFT.cdc")
+    deploy("ExampleNFT", "../contracts/standard/ExampleNFT.cdc")
     deploy("ExampleToken", "../contracts/standard/ExampleToken.cdc")
 
     // our main contract is last

--- a/test/HybridCustody_tests.cdc
+++ b/test/HybridCustody_tests.cdc
@@ -2,7 +2,7 @@ import Test
 import "test_helpers.cdc"
 
 access(all) let adminAccount = Test.getAccount(0x0000000000000007)
-access(all) let accounts: {String: Test.Account} = {}
+access(all) let accounts: {String: Test.TestAccount} = {}
 
 access(all) let app = "app"
 access(all) let child = "child"
@@ -870,7 +870,7 @@ fun testBlockchainNativeOnboarding() {
 
     let childAddresses = scriptExecutor("hybrid-custody/get_child_addresses.cdc", [parent.address]) as! [Address]?
         ?? panic("problem adding blockchain native child account to signing parent")
-    let child = Test.Account(address: childAddresses[0], publicKey: expectedPubKey)
+    let child = Test.TestAccount(address: childAddresses[0], publicKey: expectedPubKey)
 
     Test.assert(checkForAddresses(child: child, parent: parent), message: "child account not linked to parent")
 }
@@ -952,7 +952,7 @@ fun testGetChildAccountCapabilityFilterAndFactory() {
 // --------------- Transaction wrapper functions ---------------
 
 access(all)
-fun setupChildAndParent_FilterKindAll(child: Test.Account, parent: Test.Account) {
+fun setupChildAndParent_FilterKindAll(child: Test.TestAccount, parent: Test.TestAccount) {
     let factory = getTestAccount(nftFactory)
     let filter = getTestAccount(FilterKindAll)
 
@@ -966,22 +966,22 @@ fun setupChildAndParent_FilterKindAll(child: Test.Account, parent: Test.Account)
 }
 
 access(all)
-fun setupAccountManager(_ acct: Test.Account) {
+fun setupAccountManager(_ acct: Test.TestAccount) {
     txExecutor("hybrid-custody/setup_manager.cdc", [acct], [nil, nil], nil)
 }
 
 access(all)
-fun setAccountManagerWithFilter(_ acct: Test.Account, _ filterAccount: Test.Account) {
+fun setAccountManagerWithFilter(_ acct: Test.TestAccount, _ filterAccount: Test.TestAccount) {
     txExecutor("hybrid-custody/setup_manager.cdc", [acct], [nil, nil], nil)
 }
 
 access(all)
-fun setManagerFilterOnChild(child: Test.Account, parent: Test.Account, filterAddress: Address) {
+fun setManagerFilterOnChild(child: Test.TestAccount, parent: Test.TestAccount, filterAddress: Address) {
     txExecutor("hybrid-custody/set_manager_filter_cap.cdc", [parent], [filterAddress, child.address], nil)
 }
 
 access(all)
-fun setupOwnedAccount(_ acct: Test.Account, _ filterKind: String) {
+fun setupOwnedAccount(_ acct: Test.TestAccount, _ filterKind: String) {
     let factory = getTestAccount(nftFactory)
     let filter = getTestAccount(filterKind)
 
@@ -996,54 +996,54 @@ fun setupOwnedAccount(_ acct: Test.Account, _ filterKind: String) {
 }
 
 access(all)
-fun setupFactoryManager(_ acct: Test.Account) {
+fun setupFactoryManager(_ acct: Test.TestAccount) {
     txExecutor("factory/setup_nft_ft_manager.cdc", [acct], [], nil)
 }
 
 access(all)
-fun setupNFTCollection(_ acct: Test.Account) {
+fun setupNFTCollection(_ acct: Test.TestAccount) {
     txExecutor("example-nft/setup_full.cdc", [acct], [], nil)
 }
 
 access(all)
-fun setupNFT2Collection(_ acct: Test.Account) {
+fun setupNFT2Collection(_ acct: Test.TestAccount) {
     txExecutor("example-nft-2/setup_full.cdc", [acct], [], nil)
 }
 
 access(all)
-fun mintNFT(_ minter: Test.Account, receiver: Test.Account, name: String, description: String, thumbnail: String) {
+fun mintNFT(_ minter: Test.TestAccount, receiver: Test.TestAccount, name: String, description: String, thumbnail: String) {
     let filepath: String = "example-nft/mint_to_account.cdc"
     txExecutor(filepath, [minter], [receiver.address, name, description, thumbnail], nil)
 }
 
 access(all)
-fun mintNFTDefault(_ minter: Test.Account, receiver: Test.Account) {
+fun mintNFTDefault(_ minter: Test.TestAccount, receiver: Test.TestAccount) {
     return mintNFT(minter, receiver: receiver, name: "example nft", description: "lorem ipsum", thumbnail: "http://example.com/image.png")
 }
 
 access(all)
-fun mintExampleNFT2(_ minter: Test.Account, receiver: Test.Account, name: String, description: String, thumbnail: String) {
+fun mintExampleNFT2(_ minter: Test.TestAccount, receiver: Test.TestAccount, name: String, description: String, thumbnail: String) {
     let filepath: String = "example-nft-2/mint_to_account.cdc"
     txExecutor(filepath, [minter], [receiver.address, name, description, thumbnail], nil)
 }
 
 access(all)
-fun mintExampleNFT2Default(_ minter: Test.Account, receiver: Test.Account) {
+fun mintExampleNFT2Default(_ minter: Test.TestAccount, receiver: Test.TestAccount) {
     return mintExampleNFT2(minter, receiver: receiver, name: "example nft 2", description: "lorem ipsum", thumbnail: "http://example.com/image.png")
 }
 
 access(all)
-fun setupFT(_ acct: Test.Account) {
+fun setupFT(_ acct: Test.TestAccount) {
     txExecutor("example-token/setup.cdc", [acct], [], nil)
 }
 
 access(all)
-fun setupFTProvider(_ acct: Test.Account) {
+fun setupFTProvider(_ acct: Test.TestAccount) {
     txExecutor("example-token/setup_provider.cdc", [acct], [], nil)
 }
 
 access(all)
-fun setupFilter(_ acct: Test.Account, _ kind: String) {
+fun setupFilter(_ acct: Test.TestAccount, _ kind: String) {
     var filePath = ""
     switch kind {
         case FilterKindAll:
@@ -1063,7 +1063,7 @@ fun setupFilter(_ acct: Test.Account, _ kind: String) {
 }
 
 access(all)
-fun addTypeToFilter(_ acct: Test.Account, _ kind: String, _ identifier: String) {
+fun addTypeToFilter(_ acct: Test.TestAccount, _ kind: String, _ identifier: String) {
     var filePath = ""
     switch kind {
         case FilterKindAllowList:
@@ -1080,7 +1080,7 @@ fun addTypeToFilter(_ acct: Test.Account, _ kind: String, _ identifier: String) 
 }
 
 access(all)
-fun removeAllFilterTypes(_ acct: Test.Account, _ kind: String) {
+fun removeAllFilterTypes(_ acct: Test.TestAccount, _ kind: String) {
     var filePath = ""
     switch kind {
         case FilterKindAllowList:
@@ -1097,12 +1097,12 @@ fun removeAllFilterTypes(_ acct: Test.Account, _ kind: String) {
 }
 
 access(all)
-fun addNFTCollectionToDelegator(child: Test.Account, parent: Test.Account, isPublic: Bool) {
+fun addNFTCollectionToDelegator(child: Test.TestAccount, parent: Test.TestAccount, isPublic: Bool) {
     txExecutor("hybrid-custody/add_example_nft_collection_to_delegator.cdc", [child], [parent.address, isPublic], nil)
 }
 
 access(all)
-fun addNFT2CollectionToDelegator(child: Test.Account, parent: Test.Account, isPublic: Bool) {
+fun addNFT2CollectionToDelegator(child: Test.TestAccount, parent: Test.TestAccount, isPublic: Bool) {
     txExecutor("hybrid-custody/add_example_nft2_collection_to_delegator.cdc", [child], [parent.address, isPublic], nil)
 }
 // ---------------- End Transaction wrapper functions
@@ -1110,32 +1110,32 @@ fun addNFT2CollectionToDelegator(child: Test.Account, parent: Test.Account, isPu
 // ---------------- Begin script wrapper functions
 
 access(all)
-fun getParentStatusesForChild(_ child: Test.Account): {Address: Bool} {
+fun getParentStatusesForChild(_ child: Test.TestAccount): {Address: Bool} {
     return scriptExecutor("hybrid-custody/get_parents_from_child.cdc", [child.address])! as! {Address: Bool}
 }
 
 access(all)
-fun isParent(child: Test.Account, parent: Test.Account): Bool {
+fun isParent(child: Test.TestAccount, parent: Test.TestAccount): Bool {
     return scriptExecutor("hybrid-custody/is_parent.cdc", [child.address, parent.address])! as! Bool
 }
 
 access(all)
-fun checkIsRedeemed(child: Test.Account, parent: Test.Account): Bool {
+fun checkIsRedeemed(child: Test.TestAccount, parent: Test.TestAccount): Bool {
     return scriptExecutor("hybrid-custody/is_redeemed.cdc", [child.address, parent.address])! as! Bool
 }
 
 access(all)
-fun getNumValidKeys(_ child: Test.Account): Int {
+fun getNumValidKeys(_ child: Test.TestAccount): Int {
     return scriptExecutor("hybrid-custody/get_num_valid_keys.cdc", [child.address])! as! Int
 }
 
 access(all)
-fun checkAuthAccountDefaultCap(account: Test.Account): Bool {
+fun checkAuthAccountDefaultCap(account: Test.TestAccount): Bool {
     return scriptExecutor("hybrid-custody/check_default_auth_acct_linked_path.cdc", [account.address])! as! Bool
 }
 
 access(all)
-fun getOwner(child: Test.Account): Address? {
+fun getOwner(child: Test.TestAccount): Address? {
     let res = scriptExecutor("hybrid-custody/get_owner_of_child.cdc", [child.address])
     if res == nil {
         return nil
@@ -1145,14 +1145,14 @@ fun getOwner(child: Test.Account): Address? {
 }
 
 access(all)
-fun getPendingOwner(child: Test.Account): Address? {
+fun getPendingOwner(child: Test.TestAccount): Address? {
     let res = scriptExecutor("hybrid-custody/get_pending_owner_of_child.cdc", [child.address])
 
     return res as! Address?
 }
 
 access(all)
-fun checkForAddresses(child: Test.Account, parent: Test.Account): Bool {
+fun checkForAddresses(child: Test.TestAccount, parent: Test.TestAccount): Bool {
     let childAddressResult: [Address]? = (scriptExecutor("hybrid-custody/get_child_addresses.cdc", [parent.address])) as! [Address]?
     Test.assert(childAddressResult?.contains(child.address) == true, message: "child address not found")
 
@@ -1162,7 +1162,7 @@ fun checkForAddresses(child: Test.Account, parent: Test.Account): Bool {
 }
 
 access(all)
-fun getBalance(_ acct: Test.Account): UFix64 {
+fun getBalance(_ acct: Test.TestAccount): UFix64 {
     let balance: UFix64? = (scriptExecutor("example-token/get_balance.cdc", [acct.address])! as! UFix64)
     return balance!
 }
@@ -1172,7 +1172,7 @@ fun getBalance(_ acct: Test.Account): UFix64 {
 // ---------------- BEGIN General-purpose helper functions
 
 access(all)
-fun buildTypeIdentifier(_ acct: Test.Account, _ contractName: String, _ suffix: String): String {
+fun buildTypeIdentifier(_ acct: Test.TestAccount, _ contractName: String, _ suffix: String): String {
     let addrString = acct.address.toString()
     return "A.".concat(addrString.slice(from: 2, upTo: addrString.length)).concat(".").concat(contractName).concat(".").concat(suffix)
 }
@@ -1187,7 +1187,7 @@ fun getCapabilityFilterPath(): String {
 // ---------------- END General-purpose helper functions
 
 access(all)
-fun getTestAccount(_ name: String): Test.Account {
+fun getTestAccount(_ name: String): Test.TestAccount {
     if accounts[name] == nil {
         accounts[name] = Test.createAccount()
     }

--- a/test/test_helpers.cdc
+++ b/test/test_helpers.cdc
@@ -49,7 +49,7 @@ fun expectScriptFailure(
 access(all)
 fun txExecutor(
     _ txName: String,
-    _ signers: [Test.Account],
+    _ signers: [Test.TestAccount],
     _ arguments: [AnyStruct],
     _ expectedError: String?
 ): Bool {

--- a/transactions/delegator/add_private_nft_collection.cdc
+++ b/transactions/delegator/add_private_nft_collection.cdc
@@ -5,13 +5,13 @@ import "MetadataViews"
 import "ExampleNFT"
 
 transaction {
-    prepare(acct: AuthAccount) {
-        let delegator = acct.borrow<&CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath)
+    prepare(acct: auth(BorrowValue, Capabilities) &Account) {
+        let delegator = acct.storage.borrow<auth(Mutate) &CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath)
             ?? panic("delegator not found")
         
-        let d = ExampleNFT.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
+        let d = ExampleNFT.resolveContractView(resourceType: nil, viewType: Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
         
-        let sharedCap = acct.getCapability<&ExampleNFT.Collection{NonFungibleToken.Provider}>(d.providerPath)
+        let sharedCap = acct.capabilities.storage.issue<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>(d.storagePath)
         
         delegator.addCapability(cap: sharedCap, isPublic: false)
     }

--- a/transactions/delegator/add_public_nft_collection.cdc
+++ b/transactions/delegator/add_public_nft_collection.cdc
@@ -4,12 +4,12 @@ import "NonFungibleToken"
 import "ExampleNFT"
 
 transaction {
-    prepare(acct: AuthAccount) {
-        let delegator = acct.borrow<&CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath)
+    prepare(acct: auth(BorrowValue) &Account) {
+        let delegator = acct.storage.borrow<auth(Mutate) &CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath)
             ?? panic("delegator not found")
 
         let sharedCap 
-            = acct.getCapability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>(ExampleNFT.CollectionPublicPath)
+            = acct.capabilities.get<&{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>(ExampleNFT.CollectionPublicPath)!
         delegator.addCapability(cap: sharedCap, isPublic: true)
     }
 }

--- a/transactions/delegator/remove_private_nft_collection.cdc
+++ b/transactions/delegator/remove_private_nft_collection.cdc
@@ -5,14 +5,16 @@ import "MetadataViews"
 import "ExampleNFT"
 
 transaction {
-    prepare(acct: AuthAccount) {
-        let delegator = acct.borrow<&CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath)
+    prepare(acct: auth(BorrowValue, Capabilities) &Account) {
+        let delegator = acct.storage.borrow<auth(Mutate) &CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath)
             ?? panic("delegator not found")
         
-        let d = ExampleNFT.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
+        let d = ExampleNFT.resolveContractView(resourceType: nil, viewType: Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
         
-        let sharedCap = acct.getCapability<&ExampleNFT.Collection{NonFungibleToken.Provider}>(d.providerPath)
+        let sharedCap = acct.capabilities.storage.issue<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Provider}>(d.storagePath)
         
         delegator.removeCapability(cap: sharedCap)
+
+        acct.capabilities.storage.getController(byCapabilityID: sharedCap.id)!.delete()
     }
 }

--- a/transactions/delegator/remove_public_nft_collection.cdc
+++ b/transactions/delegator/remove_public_nft_collection.cdc
@@ -4,12 +4,12 @@ import "NonFungibleToken"
 import "ExampleNFT"
 
 transaction {
-    prepare(acct: AuthAccount) {
-        let delegator = acct.borrow<&CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath)
+    prepare(acct: auth(BorrowValue, Capabilities) &Account) {
+        let delegator = acct.storage.borrow<auth(Mutate) &CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath)
             ?? panic("delegator not found")
 
         let sharedCap 
-            = acct.getCapability<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>(ExampleNFT.CollectionPublicPath)
+            = acct.capabilities.get<&{ExampleNFT.ExampleNFTCollectionPublic, NonFungibleToken.CollectionPublic}>(ExampleNFT.CollectionPublicPath)!
         delegator.removeCapability(cap: sharedCap)
     }
 }

--- a/transactions/delegator/setup.cdc
+++ b/transactions/delegator/setup.cdc
@@ -1,16 +1,15 @@
 import "CapabilityDelegator"
 
 transaction {
-    prepare(acct: AuthAccount) {
-        if acct.borrow<&CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath) == nil {
+    prepare(acct: auth(Storage, Capabilities) &Account) {
+        if acct.storage.borrow<&CapabilityDelegator.Delegator>(from: CapabilityDelegator.StoragePath) == nil {
             let delegator <- CapabilityDelegator.createDelegator()
-            acct.save(<-delegator, to: CapabilityDelegator.StoragePath)
+            acct.storage.save(<-delegator, to: CapabilityDelegator.StoragePath)
         }
 
-        acct.unlink(CapabilityDelegator.PublicPath)
-        acct.unlink(CapabilityDelegator.PrivatePath)
+        acct.capabilities.unpublish(CapabilityDelegator.PublicPath)
 
-        acct.link<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPublic}>(CapabilityDelegator.PublicPath, target: CapabilityDelegator.StoragePath)
-        acct.link<&CapabilityDelegator.Delegator{CapabilityDelegator.GetterPublic, CapabilityDelegator.GetterPrivate}>(CapabilityDelegator.PrivatePath, target: CapabilityDelegator.StoragePath)
+        let cap = acct.capabilities.storage.issue<&{CapabilityDelegator.GetterPublic}>(CapabilityDelegator.StoragePath)
+        acct.capabilities.publish(cap, at: CapabilityDelegator.PublicPath)
     }
 }

--- a/transactions/example-nft-2/mint_to_account.cdc
+++ b/transactions/example-nft-2/mint_to_account.cdc
@@ -6,15 +6,15 @@ import "ExampleNFT2"
 transaction(receiver: Address, name: String, description: String, thumbnail: String) {
     let minter: &ExampleNFT2.NFTMinter
 
-    prepare(acct: AuthAccount) {
-        self.minter = acct.borrow<&ExampleNFT2.NFTMinter>(from: ExampleNFT2.MinterStoragePath) ?? panic("minter not found")
+    prepare(acct: auth(BorrowValue) &Account) {
+        self.minter = acct.storage.borrow<&ExampleNFT2.NFTMinter>(from: ExampleNFT2.MinterStoragePath) ?? panic("minter not found")
     }
 
     execute {
-        let d = ExampleNFT2.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
+        let d = ExampleNFT2.resolveContractView(resourceType: nil, viewType: Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
 
-        let c = getAccount(receiver).getCapability<&{NonFungibleToken.CollectionPublic}>(d.publicPath)
+        let c = getAccount(receiver).capabilities.get<&{NonFungibleToken.CollectionPublic}>(d.publicPath) ?? panic("receiver capability was nil")
         let r = c.borrow() ?? panic("no receiver collection")
-        self.minter.mintNFT(recipient: r, name: name, description: description, thumbnail: thumbnail, royalties: [])
+        self.minter.mintNFT(recipient: r, name: name, description: description, thumbnail: thumbnail, royaltyReceipient: self.minter.owner!.address)
     }
 }

--- a/transactions/example-nft-2/setup_full.cdc
+++ b/transactions/example-nft-2/setup_full.cdc
@@ -4,17 +4,19 @@ import "MetadataViews"
 import "ExampleNFT2"
 
 transaction {
-    prepare(acct: AuthAccount) {
-        let d = ExampleNFT2.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
+    prepare(acct: auth(Storage, Capabilities) &Account) {
+        let d = ExampleNFT2.resolveContractView(resourceType: nil, viewType: Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
 
-        if acct.borrow<&ExampleNFT2.Collection>(from: d.storagePath) == nil {
-            acct.save(<- ExampleNFT2.createEmptyCollection(), to: ExampleNFT2.CollectionStoragePath)
+        if acct.storage.borrow<&ExampleNFT2.Collection>(from: d.storagePath) == nil {
+            acct.storage.save(<- ExampleNFT2.createEmptyCollection(), to: ExampleNFT2.CollectionStoragePath)
         }
 
-        acct.unlink(d.publicPath)
-        acct.link<&ExampleNFT2.Collection{ExampleNFT2.ExampleNFT2CollectionPublic, NonFungibleToken.CollectionPublic}>(d.publicPath, target: d.storagePath)
+        acct.capabilities.unpublish(d.publicPath)
+        acct.capabilities.publish(
+            acct.capabilities.storage.issue<&{ExampleNFT2.ExampleNFT2CollectionPublic, NonFungibleToken.CollectionPublic}>(d.storagePath),
+            at: d.publicPath
+        )
 
-        acct.unlink(d.providerPath)
-        acct.link<&ExampleNFT2.Collection{ExampleNFT2.ExampleNFT2CollectionPublic, NonFungibleToken.CollectionPublic, NonFungibleToken.Provider}>(d.providerPath, target: d.storagePath)
+        acct.capabilities.storage.issue<auth(NonFungibleToken.Withdraw) &{ExampleNFT2.ExampleNFT2CollectionPublic, NonFungibleToken.CollectionPublic, NonFungibleToken.Provider}>(d.storagePath)
     }
 }

--- a/transactions/example-nft/mint_to_account.cdc
+++ b/transactions/example-nft/mint_to_account.cdc
@@ -6,15 +6,15 @@ import "ExampleNFT"
 transaction(receiver: Address, name: String, description: String, thumbnail: String) {
     let minter: &ExampleNFT.NFTMinter
 
-    prepare(acct: AuthAccount) {
-        self.minter = acct.borrow<&ExampleNFT.NFTMinter>(from: ExampleNFT.MinterStoragePath) ?? panic("minter not found")
+    prepare(acct: auth(BorrowValue) &Account) {
+        self.minter = acct.storage.borrow<&ExampleNFT.NFTMinter>(from: ExampleNFT.MinterStoragePath) ?? panic("minter not found")
     }
 
     execute {
-        let d = ExampleNFT.resolveView(Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
+        let d = ExampleNFT.resolveContractView(resourceType: nil, viewType: Type<MetadataViews.NFTCollectionData>())! as! MetadataViews.NFTCollectionData
 
-        let c = getAccount(receiver).getCapability<&{NonFungibleToken.CollectionPublic}>(d.publicPath)
+        let c = getAccount(receiver).capabilities.get<&{NonFungibleToken.CollectionPublic}>(d.publicPath) ?? panic("receiver capability was nil")
         let r = c.borrow() ?? panic("no receiver collection")
-        self.minter.mintNFT(recipient: r, name: name, description: description, thumbnail: thumbnail, royalties: [])
+        self.minter.mintNFT(recipient: r, name: name, description: description, thumbnail: thumbnail, royaltyReceipient: self.minter.owner!.address)
     }
 }

--- a/transactions/example-token/mint_tokens.cdc
+++ b/transactions/example-token/mint_tokens.cdc
@@ -1,4 +1,5 @@
 import "FungibleToken"
+import "FungibleTokenMetadataViews"
 import "ExampleToken"
 
 //EMULATOR transaction only! Emulator contract does not require admin resource
@@ -8,21 +9,20 @@ import "ExampleToken"
 /// are transferred to the address after minting
 
 transaction(recipient: Address, amount: UFix64) {
-
-
     /// Reference to the Fungible Token Receiver of the recipient
     let tokenReceiver: &{FungibleToken.Receiver}
 
     /// The total supply of tokens before the burn
     let supplyBefore: UFix64
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: auth(Storage, Capabilities) &Account) {
         self.supplyBefore = ExampleToken.totalSupply
 
+        let vaultData = ExampleToken.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>()) as! FungibleTokenMetadataViews.FTVaultData?
+            ?? panic("Could not get the vault data view for ExampleToken")
+
         // Get the account of the recipient and borrow a reference to their receiver
-        self.tokenReceiver = getAccount(recipient)
-            .getCapability(ExampleToken.ReceiverPublicPath)
-            .borrow<&{FungibleToken.Receiver}>()
+        self.tokenReceiver = getAccount(recipient).capabilities.get<&{FungibleToken.Receiver}>(vaultData.receiverPath)!.borrow()
             ?? panic("Unable to borrow receiver reference")
     }
 

--- a/transactions/example-token/setup.cdc
+++ b/transactions/example-token/setup.cdc
@@ -1,28 +1,33 @@
 import "FungibleToken"
 import "ExampleToken"
+import "FungibleTokenMetadataViews"
 
 transaction {
-    prepare(acct: AuthAccount) {
+    prepare(acct: auth(Storage, Capabilities) &Account) {
+        let md = ExampleToken.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>())! as! FungibleTokenMetadataViews.FTVaultData
         // Create a new ExampleToken Vault and put it in storage if one doesn't exist
-        if acct.borrow<&ExampleToken.Vault>(from: ExampleToken.VaultStoragePath) == nil {
-        acct.save(
-            <-ExampleToken.createEmptyVault(),
-            to: ExampleToken.VaultStoragePath
-        )
+        if acct.storage.borrow<&ExampleToken.Vault>(from: md.storagePath) == nil {
+            acct.storage.save(
+                <-ExampleToken.createEmptyVault(vaultType: Type<@ExampleToken.Vault>()),
+                to: md.storagePath
+            )
         }
 
         // Create a public capability to the Vault that only exposes
         // the deposit function through the Receiver interface
-        acct.link<&ExampleToken.Vault{FungibleToken.Receiver, FungibleToken.Balance}>(
-            ExampleToken.ReceiverPublicPath,
-            target: ExampleToken.VaultStoragePath
+        acct.capabilities.unpublish(md.receiverPath)
+        acct.capabilities.publish(
+            acct.capabilities.storage.issue<&{FungibleToken.Receiver, FungibleToken.Balance}>(md.storagePath),
+            at: md.receiverPath
         )
 
         // Create a public capability to the Vault that exposes the Balance and Resolver interfaces
-        acct.link<&ExampleToken.Vault{FungibleToken.Balance}>(
-            ExampleToken.VaultPublicPath,
-            target: ExampleToken.VaultStoragePath
+        acct.capabilities.unpublish(md.metadataPath)
+        acct.capabilities.publish(
+            acct.capabilities.storage.issue<&{FungibleToken.Balance}>(md.storagePath),
+            at: md.metadataPath
         )
+
     }
 }
  

--- a/transactions/example-token/setup_provider.cdc
+++ b/transactions/example-token/setup_provider.cdc
@@ -1,13 +1,13 @@
 import "FungibleToken"
 import "ExampleToken"
+import "FungibleTokenMetadataViews"
 
 transaction {
-    prepare(acct: AuthAccount) {
-    // Create Provider capability that can be used by parent to access the child's vault and transfer tokens
-     let providerPath = /private/exampleTokenProvider
-
-        acct.unlink(providerPath)
-        acct.link<&{FungibleToken.Provider}>(providerPath, target: ExampleToken.VaultStoragePath)
+    prepare(acct: auth(Capabilities) &Account) {
+        let vaultData = ExampleToken.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>()) as! FungibleTokenMetadataViews.FTVaultData?
+            ?? panic("Could not get the vault data view for ExampleToken")
+    
+        acct.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>(vaultData.storagePath)
     }
 }
  

--- a/transactions/factory/setup_empty_factory.cdc
+++ b/transactions/factory/setup_empty_factory.cdc
@@ -1,0 +1,25 @@
+import "NonFungibleToken"
+import "FungibleToken"
+
+import "CapabilityFactory"
+
+transaction {
+    prepare(acct: auth(Storage, Capabilities) &Account) {
+        if acct.storage.borrow<&AnyResource>(from: CapabilityFactory.StoragePath) == nil {
+            let f <- CapabilityFactory.createFactoryManager()
+            acct.storage.save(<-f, to: CapabilityFactory.StoragePath)
+        }
+
+        if acct.capabilities.get<&{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)?.check() != true {
+            acct.capabilities.unpublish(CapabilityFactory.PublicPath)
+
+            let cap = acct.capabilities.storage.issue<&{CapabilityFactory.Getter}>(CapabilityFactory.StoragePath)
+            acct.capabilities.publish(cap, at: CapabilityFactory.PublicPath)
+        }
+
+        assert(
+            acct.capabilities.get<&{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)!.check(),
+            message: "CapabilityFactory is not setup properly"
+        )
+    }
+}

--- a/transactions/factory/setup_ft_manager.cdc
+++ b/transactions/factory/setup_ft_manager.cdc
@@ -8,29 +8,32 @@ import "FTReceiverFactory"
 import "FTAllFactory"
 
 transaction {
-    prepare(acct: AuthAccount) {
-        if acct.borrow<&AnyResource>(from: CapabilityFactory.StoragePath) == nil {
+    prepare(acct: auth(Storage, Capabilities) &Account) {
+        if acct.storage.borrow<&AnyResource>(from: CapabilityFactory.StoragePath) == nil {
             let f <- CapabilityFactory.createFactoryManager()
-            acct.save(<-f, to: CapabilityFactory.StoragePath)
+            acct.storage.save(<-f, to: CapabilityFactory.StoragePath)
         }
 
-        if !acct.getCapability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath).check() {
-            acct.unlink(CapabilityFactory.PublicPath)
-            acct.link<&CapabilityFactory.Manager{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath, target: CapabilityFactory.StoragePath)
+        if acct.capabilities.get<&{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)?.check() != true {
+            acct.capabilities.unpublish(CapabilityFactory.PublicPath)
+            acct.capabilities.publish(
+                acct.capabilities.storage.issue<&{CapabilityFactory.Getter}>(CapabilityFactory.StoragePath), 
+                at: CapabilityFactory.PublicPath
+            )
         }
 
         assert(
-            acct.getCapability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath).check(),
+            acct.capabilities.get<&{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)!.check(),
             message: "CapabilityFactory is not setup properly"
         )
 
-        let manager = acct.borrow<&CapabilityFactory.Manager>(from: CapabilityFactory.StoragePath)
+        let manager = acct.storage.borrow<auth(Mutate) &CapabilityFactory.Manager>(from: CapabilityFactory.StoragePath)
             ?? panic("manager not found")
 
-        manager.updateFactory(Type<&{FungibleToken.Provider}>(), FTProviderFactory.Factory())
+        manager.updateFactory(Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>(), FTProviderFactory.Factory())
         manager.updateFactory(Type<&{FungibleToken.Balance}>(), FTBalanceFactory.Factory())
         manager.updateFactory(Type<&{FungibleToken.Receiver}>(), FTReceiverFactory.Factory())
         manager.updateFactory(Type<&{FungibleToken.Receiver, FungibleToken.Balance}>(), FTReceiverBalanceFactory.Factory())
-        manager.updateFactory(Type<&{FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance}>(), FTAllFactory.Factory())
+        manager.updateFactory(Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider, FungibleToken.Receiver, FungibleToken.Balance}>(), FTAllFactory.Factory())
     }
 }

--- a/transactions/filter/allow/add_type_to_list.cdc
+++ b/transactions/filter/allow/add_type_to_list.cdc
@@ -1,8 +1,8 @@
 import "CapabilityFilter"
 
 transaction(identifier: String) {
-    prepare(acct: AuthAccount) {
-        let filter = acct.borrow<&CapabilityFilter.AllowlistFilter>(from: CapabilityFilter.StoragePath)
+    prepare(acct: auth(Storage) &Account) {
+        let filter = acct.storage.borrow<auth(Mutate) &CapabilityFilter.AllowlistFilter>(from: CapabilityFilter.StoragePath)
             ?? panic("filter does not exist")
 
         let c = CompositeType(identifier)!

--- a/transactions/filter/allow/remove_all_types.cdc
+++ b/transactions/filter/allow/remove_all_types.cdc
@@ -1,8 +1,8 @@
 import "CapabilityFilter"
 
 transaction() {
-    prepare(acct: AuthAccount) {
-        let filter = acct.borrow<&CapabilityFilter.AllowlistFilter>(from: CapabilityFilter.StoragePath)
+    prepare(acct: auth(Storage) &Account) {
+        let filter = acct.storage.borrow<auth(Mutate) &CapabilityFilter.AllowlistFilter>(from: CapabilityFilter.StoragePath)
             ?? panic("filter does not exist")
 
         filter.removeAllTypes()

--- a/transactions/filter/allow/setup.cdc
+++ b/transactions/filter/allow/setup.cdc
@@ -1,12 +1,17 @@
 import "CapabilityFilter"
 
 transaction {
-    prepare(acct: AuthAccount) {
-        if acct.borrow<&CapabilityFilter.AllowlistFilter>(from: CapabilityFilter.StoragePath) == nil {
-            acct.save(<-CapabilityFilter.create(Type<@CapabilityFilter.AllowlistFilter>()), to: CapabilityFilter.StoragePath)
+    prepare(acct: auth(Storage, Capabilities) &Account) {
+        if acct.storage.borrow<&AnyResource>(from: CapabilityFilter.StoragePath) == nil {
+            acct.storage.save(<-CapabilityFilter.createFilter(Type<@CapabilityFilter.AllowlistFilter>()), to: CapabilityFilter.StoragePath)
         }
 
-        acct.unlink(CapabilityFilter.PublicPath)
-        acct.link<&CapabilityFilter.AllowlistFilter{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath, target: CapabilityFilter.StoragePath)
+        acct.capabilities.unpublish(CapabilityFilter.PublicPath)
+        acct.capabilities.publish(
+            acct.capabilities.storage.issue<&{CapabilityFilter.Filter}>(CapabilityFilter.StoragePath),
+            at: CapabilityFilter.PublicPath
+        )
+
+        assert(acct.capabilities.get<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)?.check() == true, message: "failed to setup filter")
     }
 }

--- a/transactions/filter/deny/add_type_to_list.cdc
+++ b/transactions/filter/deny/add_type_to_list.cdc
@@ -1,8 +1,8 @@
 import "CapabilityFilter"
 
 transaction(identifier: String) {
-    prepare(acct: AuthAccount) {
-        let filter = acct.borrow<&CapabilityFilter.DenylistFilter>(from: CapabilityFilter.StoragePath)
+    prepare(acct: auth(Storage) &Account) {
+        let filter = acct.storage.borrow<auth(Mutate) &CapabilityFilter.DenylistFilter>(from: CapabilityFilter.StoragePath)
             ?? panic("filter does not exist")
 
         let c = CompositeType(identifier)!

--- a/transactions/filter/deny/remove_all_types.cdc
+++ b/transactions/filter/deny/remove_all_types.cdc
@@ -1,8 +1,8 @@
 import "CapabilityFilter"
 
 transaction() {
-    prepare(acct: AuthAccount) {
-        let filter = acct.borrow<&CapabilityFilter.DenylistFilter>(from: CapabilityFilter.StoragePath)
+    prepare(acct: auth(Storage) &Account) {
+        let filter = acct.storage.borrow<auth(Mutate) &CapabilityFilter.DenylistFilter>(from: CapabilityFilter.StoragePath)
             ?? panic("filter does not exist")
 
         filter.removeAllTypes()

--- a/transactions/filter/setup_allow_all.cdc
+++ b/transactions/filter/setup_allow_all.cdc
@@ -1,14 +1,17 @@
 import "CapabilityFilter"
 
 transaction {
-    prepare(acct: AuthAccount) {
-        if acct.borrow<&CapabilityFilter.AllowAllFilter>(from: CapabilityFilter.StoragePath) == nil {
-            acct.save(<- CapabilityFilter.create(Type<@CapabilityFilter.AllowAllFilter>()), to: CapabilityFilter.StoragePath)
+    prepare(acct: auth(Storage, Capabilities) &Account) {
+        if acct.storage.borrow<&CapabilityFilter.AllowAllFilter>(from: CapabilityFilter.StoragePath) == nil {
+            acct.storage.save(<- CapabilityFilter.createFilter(Type<@CapabilityFilter.AllowAllFilter>()), to: CapabilityFilter.StoragePath)
         }
 
-        acct.unlink(CapabilityFilter.PublicPath)
-        let linkRes = acct.link<&CapabilityFilter.AllowAllFilter{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath, target: CapabilityFilter.StoragePath)
-            ?? panic("link failed")
-        assert(linkRes.check(), message: "failed to setup filter")
+        acct.capabilities.unpublish(CapabilityFilter.PublicPath)
+        acct.capabilities.publish(
+            acct.capabilities.storage.issue<&{CapabilityFilter.Filter}>(CapabilityFilter.StoragePath),
+            at: CapabilityFilter.PublicPath
+        )
+
+        assert(acct.capabilities.get<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)?.check() == true, message: "failed to setup filter")
     }
 }

--- a/transactions/hybrid-custody/accept_ownership.cdc
+++ b/transactions/hybrid-custody/accept_ownership.cdc
@@ -2,32 +2,41 @@
 
 import "HybridCustody"
 import "CapabilityFilter"
-import "MetadataViews"
+import "ViewResolver"
 
 transaction(childAddress: Address, filterAddress: Address?, filterPath: PublicPath?) {
-    prepare(acct: AuthAccount) {
+    prepare(acct: auth(Storage, Capabilities, Inbox) &Account) {
         var filter: Capability<&{CapabilityFilter.Filter}>? = nil
         if filterAddress != nil && filterPath != nil {
-            filter = getAccount(filterAddress!).getCapability<&{CapabilityFilter.Filter}>(filterPath!)
+            filter = getAccount(filterAddress!).capabilities.get<&{CapabilityFilter.Filter}>(filterPath!)
+                ?? panic("filter address given but capability was not found")
         }
 
-        if acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) == nil {
+        if acct.storage.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) == nil {
             let m <- HybridCustody.createManager(filter: filter)
-            acct.save(<- m, to: HybridCustody.ManagerStoragePath)
+            acct.storage.save(<- m, to: HybridCustody.ManagerStoragePath)
 
-            acct.unlink(HybridCustody.ManagerPublicPath)
-            acct.unlink(HybridCustody.ManagerPrivatePath)
+            for c in acct.capabilities.storage.getControllers(forPath: HybridCustody.ManagerStoragePath) {
+                c.delete()
+            }
 
-            acct.link<&HybridCustody.Manager{HybridCustody.ManagerPrivate, HybridCustody.ManagerPublic}>(HybridCustody.ManagerPrivatePath, target: HybridCustody.ManagerStoragePath)
-            acct.link<&HybridCustody.Manager{HybridCustody.ManagerPublic}>(HybridCustody.ManagerPublicPath, target: HybridCustody.ManagerStoragePath)
+            acct.capabilities.unpublish(HybridCustody.ManagerPublicPath)
+
+            acct.capabilities.storage.issue<auth(HybridCustody.Manage) &{HybridCustody.ManagerPrivate, HybridCustody.ManagerPublic}>(HybridCustody.ManagerStoragePath)
+            acct.capabilities.publish(
+                acct.capabilities.storage.issue<&{HybridCustody.ManagerPublic}>(HybridCustody.ManagerStoragePath),
+                at: HybridCustody.ManagerPublicPath
+            )
         }
 
         let inboxName = HybridCustody.getOwnerIdentifier(acct.address) 
-        let cap = acct.inbox.claim<&AnyResource{HybridCustody.OwnedAccountPrivate, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(inboxName, provider: childAddress)
+        let cap = acct.inbox.claim<auth(HybridCustody.Owner) &{HybridCustody.OwnedAccountPrivate, HybridCustody.OwnedAccountPublic, ViewResolver.Resolver}>(inboxName, provider: childAddress)
             ?? panic("owned account cap not found")
 
-        let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+        let manager = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager no found")
+
+        let ownedAcct = cap.borrow() ?? panic("could not borrow owned account capability")
 
         manager.addOwnedAccount(cap: cap)
     }

--- a/transactions/hybrid-custody/add_example_nft2_collection_to_delegator.cdc
+++ b/transactions/hybrid-custody/add_example_nft2_collection_to_delegator.cdc
@@ -5,16 +5,13 @@ import "NonFungibleToken"
 import "ExampleNFT2"
 
 transaction(parent: Address, isPublic: Bool) {
-    prepare(acct: AuthAccount) {
-        let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+    prepare(acct: auth(Storage, Capabilities) &Account) {
+        let o = acct.storage.borrow<auth(HybridCustody.Owner) &HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("owned account not found")
         let child = o.borrowChildAccount(parent: parent)
             ?? panic("child account not found")
 
-        let path = /private/exampleNFT2FullCollection
-        acct.link<&ExampleNFT2.Collection>(path, target: ExampleNFT2.CollectionStoragePath)
-        let cap = acct.getCapability<&ExampleNFT2.Collection>(path)
-
+        let cap = acct.capabilities.storage.issue<auth(NonFungibleToken.Withdraw) &ExampleNFT2.Collection>(ExampleNFT2.CollectionStoragePath)
         o.addCapabilityToDelegator(parent: parent, cap: cap, isPublic: isPublic)
     }
 }

--- a/transactions/hybrid-custody/add_example_nft_collection_to_delegator.cdc
+++ b/transactions/hybrid-custody/add_example_nft_collection_to_delegator.cdc
@@ -5,16 +5,13 @@ import "NonFungibleToken"
 import "ExampleNFT"
 
 transaction(parent: Address, isPublic: Bool) {
-    prepare(acct: AuthAccount) {
-        let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+    prepare(acct: auth(Storage, Capabilities) &Account) {
+        let o = acct.storage.borrow<auth(HybridCustody.Owner) &HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("owned account not found")
         let child: &HybridCustody.ChildAccount = o.borrowChildAccount(parent: parent)
             ?? panic("child account not found")
 
-        let path = /private/exampleNFTFullCollection
-        acct.link<&ExampleNFT.Collection>(path, target: ExampleNFT.CollectionStoragePath)
-        let cap = acct.getCapability<&ExampleNFT.Collection>(path)
-
+        let cap = acct.capabilities.storage.issue<&ExampleNFT.Collection>(ExampleNFT.CollectionStoragePath)
         o.addCapabilityToDelegator(parent: parent, cap: cap, isPublic: isPublic)
     }
 }

--- a/transactions/hybrid-custody/destroy_child.cdc
+++ b/transactions/hybrid-custody/destroy_child.cdc
@@ -1,0 +1,11 @@
+import "HybridCustody"
+import "Burner"
+
+transaction(parent: Address) {
+    prepare(acct: auth(Storage) &Account) {
+        let s = StoragePath(identifier: HybridCustody.getChildAccountIdentifier(parent))!
+        let m <- acct.storage.load<@AnyResource>(from: s)
+            ?? panic("no resource found in child account storage path")
+        Burner.burn(<- m)
+    }
+}

--- a/transactions/hybrid-custody/destroy_manager.cdc
+++ b/transactions/hybrid-custody/destroy_manager.cdc
@@ -1,0 +1,10 @@
+import "HybridCustody"
+import "Burner"
+
+transaction {
+    prepare(acct: auth(Storage) &Account) {
+        let m <- acct.storage.load<@AnyResource>(from: HybridCustody.ManagerStoragePath)
+            ?? panic("no resource found in manager storage path")
+        Burner.burn(<- m)
+    }
+}

--- a/transactions/hybrid-custody/destroy_owned_account.cdc
+++ b/transactions/hybrid-custody/destroy_owned_account.cdc
@@ -1,0 +1,10 @@
+import "HybridCustody"
+import "Burner"
+
+transaction {
+    prepare(acct: auth(Storage) &Account) {
+        let m <- acct.storage.load<@AnyResource>(from: HybridCustody.OwnedAccountStoragePath)
+            ?? panic("no resource found in owned account storage path")
+        Burner.burn(<- m)
+    }
+}

--- a/transactions/hybrid-custody/metadata/set_child_account_display.cdc
+++ b/transactions/hybrid-custody/metadata/set_child_account_display.cdc
@@ -2,8 +2,8 @@ import "HybridCustody"
 import "MetadataViews"
 
 transaction(childAddress: Address, name: String, description: String, thumbnail: String) {
-    prepare(acct: AuthAccount) {
-        let m = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+    prepare(acct: auth(Storage) &Account) {
+        let m = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager not found")
         
         let d = MetadataViews.Display(

--- a/transactions/hybrid-custody/metadata/set_child_account_display_to_nil.cdc
+++ b/transactions/hybrid-custody/metadata/set_child_account_display_to_nil.cdc
@@ -1,0 +1,10 @@
+import "HybridCustody"
+
+transaction(childAddress: Address) {
+    prepare(acct: auth(Storage) &Account) {
+        let m = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+            ?? panic("manager not found")
+
+        m.setChildAccountDisplay(address: childAddress, nil)
+    }
+}

--- a/transactions/hybrid-custody/metadata/set_owned_account_display.cdc
+++ b/transactions/hybrid-custody/metadata/set_owned_account_display.cdc
@@ -2,8 +2,8 @@ import "HybridCustody"
 import "MetadataViews"
 
 transaction(name: String, description: String, thumbnail: String) {
-    prepare(acct: AuthAccount) {
-        let o = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+    prepare(acct: auth(Storage) &Account) {
+        let o = acct.storage.borrow<auth(HybridCustody.Owner) &HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("account not found")
         
         let d = MetadataViews.Display(

--- a/transactions/hybrid-custody/misc/save_resource_to_parent_child_storage_slot.cdc
+++ b/transactions/hybrid-custody/misc/save_resource_to_parent_child_storage_slot.cdc
@@ -2,10 +2,10 @@ import "ExampleToken"
 import "HybridCustody"
 
 transaction(parent: Address) {
-    prepare(acct: AuthAccount) {
-        let v <- ExampleToken.createEmptyVault()
+    prepare(acct: auth(Storage) &Account) {
+        let v <- ExampleToken.createEmptyVault(vaultType: Type<@ExampleToken.Vault>())
         let identifier = HybridCustody.getChildAccountIdentifier(parent)
         let storagePath = StoragePath(identifier: identifier)!
-        acct.save(<-v, to: storagePath)
+        acct.storage.save(<-v, to: storagePath)
     }
 }

--- a/transactions/hybrid-custody/publish_to_parent.cdc
+++ b/transactions/hybrid-custody/publish_to_parent.cdc
@@ -4,14 +4,14 @@ import "CapabilityFilter"
 import "CapabilityDelegator"
 
 transaction(parent: Address, factoryAddress: Address, filterAddress: Address) {
-    prepare(acct: AuthAccount) {
-        let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+    prepare(acct: auth(Storage) &Account) {
+        let owned = acct.storage.borrow<auth(HybridCustody.Owner) &HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("owned account not found")
 
-        let factory = getAccount(factoryAddress).getCapability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)
+        let factory = getAccount(factoryAddress).capabilities.get<&{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)!
         assert(factory.check(), message: "factory address is not configured properly")
 
-        let filter = getAccount(filterAddress).getCapability<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+        let filter = getAccount(filterAddress).capabilities.get<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)!
         assert(filter.check(), message: "capability filter is not configured properly")
 
         owned.publishToParent(parentAddress: parent, factory: factory, filter: filter)

--- a/transactions/hybrid-custody/redeem_account.cdc
+++ b/transactions/hybrid-custody/redeem_account.cdc
@@ -1,31 +1,40 @@
 import "MetadataViews"
+import "ViewResolver"
 
 import "HybridCustody"
 import "CapabilityFilter"
 
 transaction(childAddress: Address, filterAddress: Address?, filterPath: PublicPath?) {
-    prepare(acct: AuthAccount) {
+    prepare(acct: auth(Storage, Capabilities, Inbox) &Account) {
         var filter: Capability<&{CapabilityFilter.Filter}>? = nil
         if filterAddress != nil && filterPath != nil {
-            filter = getAccount(filterAddress!).getCapability<&{CapabilityFilter.Filter}>(filterPath!)
+            filter = getAccount(filterAddress!).capabilities.get<&{CapabilityFilter.Filter}>(filterPath!)
+                ?? panic("filter path provided but capability was not found")
         }
 
-        if acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) == nil {
+        if acct.storage.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) == nil {
             let m <- HybridCustody.createManager(filter: filter)
-            acct.save(<- m, to: HybridCustody.ManagerStoragePath)
+            acct.storage.save(<- m, to: HybridCustody.ManagerStoragePath)
 
-            acct.unlink(HybridCustody.ManagerPublicPath)
-            acct.unlink(HybridCustody.ManagerPrivatePath)
+            for c in acct.capabilities.storage.getControllers(forPath: HybridCustody.ManagerStoragePath) {
+                c.delete()
+            }
 
-            acct.link<&HybridCustody.Manager{HybridCustody.ManagerPrivate, HybridCustody.ManagerPublic}>(HybridCustody.ManagerPrivatePath, target: HybridCustody.ManagerStoragePath)
-            acct.link<&HybridCustody.Manager{HybridCustody.ManagerPublic}>(HybridCustody.ManagerPublicPath, target: HybridCustody.ManagerStoragePath)
+            acct.capabilities.unpublish(HybridCustody.ManagerPublicPath)
+
+            acct.capabilities.publish(
+                acct.capabilities.storage.issue<&{HybridCustody.ManagerPublic}>(HybridCustody.ManagerStoragePath),
+                at: HybridCustody.ManagerPublicPath
+            )
+
+            acct.capabilities.storage.issue<auth(HybridCustody.Manage) &{HybridCustody.ManagerPrivate, HybridCustody.ManagerPublic}>(HybridCustody.ManagerStoragePath)
         }
 
         let inboxName = HybridCustody.getChildAccountIdentifier(acct.address)
-        let cap = acct.inbox.claim<&HybridCustody.ChildAccount{HybridCustody.AccountPrivate, HybridCustody.AccountPublic, MetadataViews.Resolver}>(inboxName, provider: childAddress)
+        let cap = acct.inbox.claim<auth(HybridCustody.Child) &{HybridCustody.AccountPrivate, HybridCustody.AccountPublic, ViewResolver.Resolver}>(inboxName, provider: childAddress)
             ?? panic("child account cap not found")
 
-        let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+        let manager = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager no found")
 
         manager.addAccount(cap: cap)

--- a/transactions/hybrid-custody/relinquish_ownership.cdc
+++ b/transactions/hybrid-custody/relinquish_ownership.cdc
@@ -3,8 +3,8 @@
 import "HybridCustody"
 
 transaction {
-    prepare(acct: AuthAccount) {
-        let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+    prepare(acct: auth(Storage) &Account) {
+        let owned = acct.storage.borrow<auth(HybridCustody.Owner) &HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("owned not found")
         owned.seal()
     }

--- a/transactions/hybrid-custody/remove_child_account.cdc
+++ b/transactions/hybrid-custody/remove_child_account.cdc
@@ -1,8 +1,8 @@
 import "HybridCustody"
 
 transaction(child: Address) {
-    prepare (acct: AuthAccount) {
-        let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+    prepare (acct: auth(Storage) &Account) {
+        let manager = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager not found")
         manager.removeChild(addr: child)
     }

--- a/transactions/hybrid-custody/remove_owned_account.cdc
+++ b/transactions/hybrid-custody/remove_owned_account.cdc
@@ -1,0 +1,10 @@
+import "HybridCustody"
+
+transaction(addr: Address) {
+    prepare(acct: auth(Storage) &Account) {
+        let m = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+            ?? panic("manager not found")
+        
+        m.removeOwned(addr: addr)
+    }
+}

--- a/transactions/hybrid-custody/remove_parent_from_child.cdc
+++ b/transactions/hybrid-custody/remove_parent_from_child.cdc
@@ -1,13 +1,13 @@
 import "HybridCustody"
 
 transaction(parent: Address) {
-    prepare(acct: AuthAccount) {
-        let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+    prepare(acct: auth(Storage) &Account) {
+        let owned = acct.storage.borrow<auth(HybridCustody.Owner) &HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("owned not found")
 
         owned.removeParent(parent: parent)
 
-        let manager = getAccount(parent).getCapability<&HybridCustody.Manager{HybridCustody.ManagerPublic}>(HybridCustody.ManagerPublicPath)
+        let manager = getAccount(parent).capabilities.get<&{HybridCustody.ManagerPublic}>(HybridCustody.ManagerPublicPath)!
             .borrow() ?? panic("manager not found")
         let children = manager.getChildAddresses()
         assert(!children.contains(acct.address), message: "removed child is still in manager resource")

--- a/transactions/hybrid-custody/send_child_ft_with_parent.cdc
+++ b/transactions/hybrid-custody/send_child_ft_with_parent.cdc
@@ -2,22 +2,31 @@ import "FungibleToken"
 import "ExampleToken"
 
 import "HybridCustody"
+import "FungibleTokenMetadataViews"
 
 transaction(amount: UFix64, to: Address, child: Address) {
 
     // The Vault resource that holds the tokens that are being transferred
-    let paymentVault: @FungibleToken.Vault
+    let paymentVault: @{FungibleToken.Vault}
+    let vaultData: FungibleTokenMetadataViews.FTVaultData
 
-    prepare(signer: AuthAccount) {
+    prepare(signer: auth(Storage) &Account) {
         // signer is the parent account
         // get the manager resource and borrow childAccount
-        let m = signer.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+        let m = signer.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager does not exist")
         let childAcct = m.borrowAccount(addr: child) ?? panic("child account not found")
         
+        self.vaultData = ExampleToken.resolveContractView(resourceType: nil, viewType: Type<FungibleTokenMetadataViews.FTVaultData>()) as! FungibleTokenMetadataViews.FTVaultData?
+            ?? panic("Could not get the vault data view for ExampleToken")
+
         //get Ft cap from child account
-        let cap = childAcct.getCapability(path: /private/exampleTokenProvider, type: Type<&{FungibleToken.Provider}>()) ?? panic("no cap found")
-        let providerCap = cap as! Capability<&{FungibleToken.Provider}>
+        let capType = Type<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>()
+        let controllerID = childAcct.getControllerIDForType(type: capType, forPath: self.vaultData.storagePath)
+            ?? panic("no controller found for capType")
+        
+        let cap = childAcct.getCapability(controllerID: controllerID, type: capType) ?? panic("no cap found")
+        let providerCap = cap as! Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Provider}>
         assert(providerCap.check(), message: "invalid provider capability")
         
         // Get a reference to the child's stored vault
@@ -33,8 +42,7 @@ transaction(amount: UFix64, to: Address, child: Address) {
         let recipient = getAccount(to)
 
         // Get a reference to the recipient's Receiver
-        let receiverRef = recipient.getCapability(/public/exampleTokenReceiver)
-            .borrow<&{FungibleToken.Receiver}>()
+        let receiverRef = recipient.capabilities.get<&{FungibleToken.Receiver}>(self.vaultData.receiverPath)!.borrow()
 			?? panic("Could not borrow receiver reference to the recipient's Vault")
 
         // Deposit the withdrawn tokens in the recipient's receiver

--- a/transactions/hybrid-custody/set_capability_factory_for_parent.cdc
+++ b/transactions/hybrid-custody/set_capability_factory_for_parent.cdc
@@ -1,0 +1,13 @@
+import "HybridCustody"
+import "CapabilityFactory"
+
+transaction(parent: Address, factoryAddress: Address) {
+    prepare(acct: auth(Storage) &Account) {
+        let cap = getAccount(factoryAddress).capabilities.get<&{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)
+            ?? panic("capability factory was nil")
+        
+        let ownedAccount = acct.storage.borrow<auth(HybridCustody.Owner) &{HybridCustody.OwnedAccountPrivate}>(from: HybridCustody.OwnedAccountStoragePath)
+            ?? panic("owned account not found")
+        ownedAccount.setCapabilityFactoryForParent(parent: parent, cap: cap)
+    }
+}

--- a/transactions/hybrid-custody/set_capability_filter_for_parent.cdc
+++ b/transactions/hybrid-custody/set_capability_filter_for_parent.cdc
@@ -1,0 +1,13 @@
+import "HybridCustody"
+import "CapabilityFilter"
+
+transaction(parent: Address, factoryAddress: Address) {
+    prepare(acct: auth(Storage) &Account) {
+        let cap = getAccount(factoryAddress).capabilities.get<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+            ?? panic("capability filter was nil")
+        
+        let ownedAccount = acct.storage.borrow<auth(HybridCustody.Owner) &{HybridCustody.OwnedAccountPrivate}>(from: HybridCustody.OwnedAccountStoragePath)
+            ?? panic("owned account not found")
+        ownedAccount.setCapabilityFilterForParent(parent: parent, cap: cap)
+    }
+}

--- a/transactions/hybrid-custody/set_default_manager_cap.cdc
+++ b/transactions/hybrid-custody/set_default_manager_cap.cdc
@@ -4,11 +4,12 @@ import "CapabilityFilter"
 // Sets the signing account's HybridCustody.Manager.filter capability to
 // the filter which exists at the given address's public path
 transaction(addr: Address) {
-    prepare(acct: AuthAccount) {
-        let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+    prepare(acct: auth(Storage) &Account) {
+        let manager = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager not found")
         
-        let cap = getAccount(addr).getCapability<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+        let cap = getAccount(addr).capabilities.get<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+            ?? panic("invalid capability filter address found")
         manager.setDefaultManagerCapabilityFilter(cap: cap)
     }
 }

--- a/transactions/hybrid-custody/set_manager_filter_cap.cdc
+++ b/transactions/hybrid-custody/set_manager_filter_cap.cdc
@@ -2,11 +2,12 @@ import "HybridCustody"
 import "CapabilityFilter"
 
 transaction(filterAddress: Address, childAddress: Address) {
-    prepare(acct: AuthAccount) {
-        let m = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+    prepare(acct: auth(Storage) &Account) {
+        let m = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager not found")
 
-        let cap = getAccount(filterAddress).getCapability<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+        let cap = getAccount(filterAddress).capabilities.get<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+            ?? panic("failed to get filter capability")
         assert(cap.check(), message: "capability filter is not valid")
 
         m.setManagerCapabilityFilter(cap: cap, childAddress: childAddress)

--- a/transactions/hybrid-custody/setup_multi_sig.cdc
+++ b/transactions/hybrid-custody/setup_multi_sig.cdc
@@ -7,64 +7,87 @@ import "CapabilityDelegator"
 import "CapabilityFilter"
 
 import "MetadataViews"
+import "ViewResolver"
 
 transaction(parentFilterAddress: Address?, childAccountFactoryAddress: Address, childAccountFilterAddress: Address) {
-    prepare(childAcct: AuthAccount, parentAcct: AuthAccount) {
+    prepare(childAcct: auth(Storage, Capabilities) &Account, parentAcct: auth(Storage, Capabilities, Inbox) &Account) {
         // --------------------- Begin setup of child account ---------------------
-        var acctCap = childAcct.getCapability<&AuthAccount>(HybridCustody.LinkedAccountPrivatePath)
-        if !acctCap.check() {
-            acctCap = childAcct.linkAccount(HybridCustody.LinkedAccountPrivatePath)!
+        var optCap: Capability<auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account>? = nil
+        let t = Type<auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account>()
+        for c in childAcct.capabilities.account.getControllers() {
+            if c.borrowType.isSubtype(of: t) {
+                optCap = c.capability as! Capability<auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account>
+                break
+            }
         }
 
-        if childAcct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) == nil {
+        if optCap == nil {
+            optCap = childAcct.capabilities.account.issue<auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account>()
+        }
+        let acctCap = optCap ?? panic("failed to get account capability")
+
+        if childAcct.storage.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) == nil {
             let ownedAccount <- HybridCustody.createOwnedAccount(acct: acctCap)
-            childAcct.save(<-ownedAccount, to: HybridCustody.OwnedAccountStoragePath)
+            childAcct.storage.save(<-ownedAccount, to: HybridCustody.OwnedAccountStoragePath)
         }
 
-        // check that paths are all configured properly
-        childAcct.unlink(HybridCustody.OwnedAccountPrivatePath)
-        childAcct.link<&HybridCustody.OwnedAccount{HybridCustody.BorrowableAccount, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.OwnedAccountPrivatePath, target: HybridCustody.OwnedAccountStoragePath)
+        for c in childAcct.capabilities.storage.getControllers(forPath: HybridCustody.OwnedAccountStoragePath) {
+            c.delete()
+        }
 
-        childAcct.unlink(HybridCustody.OwnedAccountPublicPath)
-        childAcct.link<&HybridCustody.OwnedAccount{HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.OwnedAccountPublicPath, target: HybridCustody.OwnedAccountStoragePath)
+        // configure capabilities
+        childAcct.capabilities.storage.issue<&{HybridCustody.BorrowableAccount, HybridCustody.OwnedAccountPublic, ViewResolver.Resolver}>(HybridCustody.OwnedAccountStoragePath)
+        childAcct.capabilities.publish(
+            childAcct.capabilities.storage.issue<&{HybridCustody.OwnedAccountPublic, ViewResolver.Resolver}>(HybridCustody.OwnedAccountStoragePath),
+            at: HybridCustody.OwnedAccountPublicPath
+        )
+
         // --------------------- End setup of child account ---------------------
 
         // --------------------- Begin setup of parent account ---------------------
         var filter: Capability<&{CapabilityFilter.Filter}>? = nil
         if parentFilterAddress != nil {
-            filter = getAccount(parentFilterAddress!).getCapability<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+            filter = getAccount(parentFilterAddress!).capabilities.get<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+                ?? panic("parent filter address provided but it was not valid")
         }
 
-        if parentAcct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) == nil {
+        if parentAcct.storage.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) == nil {
             let m <- HybridCustody.createManager(filter: filter)
-            parentAcct.save(<- m, to: HybridCustody.ManagerStoragePath)
+            parentAcct.storage.save(<- m, to: HybridCustody.ManagerStoragePath)
         }
 
-        parentAcct.unlink(HybridCustody.ManagerPublicPath)
-        parentAcct.unlink(HybridCustody.ManagerPrivatePath)
+        for c in parentAcct.capabilities.storage.getControllers(forPath: HybridCustody.ManagerStoragePath) {
+            c.delete()
+        }
 
-        parentAcct.link<&HybridCustody.Manager{HybridCustody.ManagerPrivate, HybridCustody.ManagerPublic}>(HybridCustody.OwnedAccountPrivatePath, target: HybridCustody.ManagerStoragePath)
-        parentAcct.link<&HybridCustody.Manager{HybridCustody.ManagerPublic}>(HybridCustody.ManagerPublicPath, target: HybridCustody.ManagerStoragePath)
+        parentAcct.capabilities.publish(
+            parentAcct.capabilities.storage.issue<&{HybridCustody.ManagerPublic}>(HybridCustody.ManagerStoragePath),
+            at: HybridCustody.ManagerPublicPath
+        )
+        parentAcct.capabilities.storage.issue<auth(HybridCustody.Manage) &{HybridCustody.ManagerPrivate, HybridCustody.ManagerPublic}>(HybridCustody.ManagerStoragePath)
+
         // --------------------- End setup of parent account ---------------------
 
         // Publish account to parent
-        let owned = childAcct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+        let owned = childAcct.storage.borrow<auth(HybridCustody.Owner) &HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("owned account not found")
 
-        let factory = getAccount(childAccountFactoryAddress).getCapability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)
+        let factory = getAccount(childAccountFactoryAddress).capabilities.get<&{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)
+            ?? panic("child account factory capability was nil")
         assert(factory.check(), message: "factory address is not configured properly")
 
-        let filterForChild = getAccount(childAccountFilterAddress).getCapability<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+        let filterForChild = getAccount(childAccountFilterAddress).capabilities.get<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+            ?? panic("child account filter capability was nil")
         assert(filterForChild.check(), message: "capability filter is not configured properly")
 
         owned.publishToParent(parentAddress: parentAcct.address, factory: factory, filter: filterForChild)
 
         // claim the account on the parent
         let inboxName = HybridCustody.getChildAccountIdentifier(parentAcct.address)
-        let cap = parentAcct.inbox.claim<&HybridCustody.ChildAccount{HybridCustody.AccountPrivate, HybridCustody.AccountPublic, MetadataViews.Resolver}>(inboxName, provider: childAcct.address)
+        let cap = parentAcct.inbox.claim<auth(HybridCustody.Child) &{HybridCustody.AccountPrivate, HybridCustody.AccountPublic, ViewResolver.Resolver}>(inboxName, provider: childAcct.address)
             ?? panic("child account cap not found")
 
-        let manager = parentAcct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+        let manager = parentAcct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager no found")
 
         manager.addAccount(cap: cap)

--- a/transactions/hybrid-custody/setup_owned_account.cdc
+++ b/transactions/hybrid-custody/setup_owned_account.cdc
@@ -1,7 +1,7 @@
 #allowAccountLinking
 
+import "ViewResolver"
 import "MetadataViews"
-
 import "HybridCustody"
 
 /// This transaction configures an OwnedAccount in the signer if needed and configures its Capabilities per
@@ -9,33 +9,34 @@ import "HybridCustody"
 /// signer's OwnedAccount.
 ///
 transaction(name: String?, desc: String?, thumbnailURL: String?) {
-    prepare(acct: AuthAccount) {
-        var acctCap = acct.getCapability<&AuthAccount>(HybridCustody.LinkedAccountPrivatePath)
-        if !acctCap.check() {
-            acctCap = acct.linkAccount(HybridCustody.LinkedAccountPrivatePath)!
-        }
+    prepare(acct: auth(Storage, Capabilities) &Account) {
+        let acctCap = acct.capabilities.account.issue<auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account>()
 
-        if acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) == nil {
+        if acct.storage.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) == nil {
             let ownedAccount <- HybridCustody.createOwnedAccount(acct: acctCap)
-            acct.save(<-ownedAccount, to: HybridCustody.OwnedAccountStoragePath)
+            acct.storage.save(<-ownedAccount, to: HybridCustody.OwnedAccountStoragePath)
         }
 
-        let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+        let owned = acct.storage.borrow<auth(HybridCustody.Owner) &HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("owned account not found")
         
         // Set the display metadata for the OwnedAccount
         if name != nil && desc != nil && thumbnailURL != nil {
             let thumbnail = MetadataViews.HTTPFile(url: thumbnailURL!)
-            let display = MetadataViews.Display(name: name!, description: desc!, thumbnail: thumbnail!)
+            let display = MetadataViews.Display(name: name!, description: desc!, thumbnail: thumbnail)
             owned.setDisplay(display)
         }
 
         // check that paths are all configured properly
-        acct.unlink(HybridCustody.OwnedAccountPrivatePath)
-        acct.link<&HybridCustody.OwnedAccount{HybridCustody.BorrowableAccount, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.OwnedAccountPrivatePath, target: HybridCustody.OwnedAccountStoragePath)
+        for c in acct.capabilities.storage.getControllers(forPath: HybridCustody.OwnedAccountStoragePath) {
+            c.delete()
+        }
 
-        acct.unlink(HybridCustody.OwnedAccountPublicPath)
-        acct.link<&HybridCustody.OwnedAccount{HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.OwnedAccountPublicPath, target: HybridCustody.OwnedAccountStoragePath)
+        acct.capabilities.storage.issue<&{HybridCustody.BorrowableAccount, HybridCustody.OwnedAccountPublic, ViewResolver.Resolver}>(HybridCustody.OwnedAccountStoragePath)
+        acct.capabilities.publish(
+            acct.capabilities.storage.issue<&{HybridCustody.OwnedAccountPublic, ViewResolver.Resolver}>(HybridCustody.OwnedAccountStoragePath),
+            at: HybridCustody.OwnedAccountPublicPath
+        )
     }
 }
  

--- a/transactions/hybrid-custody/setup_owned_account_and_publish_to_parent.cdc
+++ b/transactions/hybrid-custody/setup_owned_account_and_publish_to_parent.cdc
@@ -1,6 +1,7 @@
 #allowAccountLinking
 
 import "MetadataViews"
+import "ViewResolver"
 
 import "HybridCustody"
 import "CapabilityFactory"
@@ -12,47 +13,49 @@ import "CapabilityDelegator"
 /// Capability on the ChildAccount is then published to the specified parent account. 
 ///
 transaction(
-        parent: Address,
-        factoryAddress: Address,
-        filterAddress: Address,
-        name: String?,
-        desc: String?,
-        thumbnailURL: String?
-    ) {
-    
-    prepare(acct: AuthAccount) {
+    parent: Address,
+    factoryAddress: Address,
+    filterAddress: Address,
+    name: String?,
+    desc: String?,
+    thumbnailURL: String?
+) {
+    prepare(acct: auth(Storage, Capabilities) &Account) {
         // Configure OwnedAccount if it doesn't exist
-        if acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) == nil {
-            var acctCap = acct.getCapability<&AuthAccount>(HybridCustody.LinkedAccountPrivatePath)
-            if !acctCap.check() {
-                acctCap = acct.linkAccount(HybridCustody.LinkedAccountPrivatePath)!
-            }
+        if acct.storage.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath) == nil {
+            var acctCap = acct.capabilities.account.issue<auth(Storage, Contracts, Keys, Inbox, Capabilities) &Account>()
             let ownedAccount <- HybridCustody.createOwnedAccount(acct: acctCap)
-            acct.save(<-ownedAccount, to: HybridCustody.OwnedAccountStoragePath)
+            acct.storage.save(<-ownedAccount, to: HybridCustody.OwnedAccountStoragePath)
         }
 
-        // check that paths are all configured properly
-        acct.unlink(HybridCustody.OwnedAccountPrivatePath)
-        acct.link<&HybridCustody.OwnedAccount{HybridCustody.BorrowableAccount, HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.OwnedAccountPrivatePath, target: HybridCustody.OwnedAccountStoragePath)
+        for c in acct.capabilities.storage.getControllers(forPath: HybridCustody.OwnedAccountStoragePath) {
+            c.delete()
+        }
 
-        acct.unlink(HybridCustody.OwnedAccountPublicPath)
-        acct.link<&HybridCustody.OwnedAccount{HybridCustody.OwnedAccountPublic, MetadataViews.Resolver}>(HybridCustody.OwnedAccountPublicPath, target: HybridCustody.OwnedAccountStoragePath)
 
-        let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+        acct.capabilities.storage.issue<&{HybridCustody.BorrowableAccount, HybridCustody.OwnedAccountPublic, ViewResolver.Resolver}>(HybridCustody.OwnedAccountStoragePath)
+        acct.capabilities.publish(
+            acct.capabilities.storage.issue<&{HybridCustody.OwnedAccountPublic, ViewResolver.Resolver}>(HybridCustody.OwnedAccountStoragePath),
+            at: HybridCustody.OwnedAccountPublicPath
+        )
+
+        let owned = acct.storage.borrow<auth(HybridCustody.Owner) &HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("owned account not found")
         
         // Set the display metadata for the OwnedAccount
         if name != nil && desc != nil && thumbnailURL != nil {
             let thumbnail = MetadataViews.HTTPFile(url: thumbnailURL!)
-            let display = MetadataViews.Display(name: name!, description: desc!, thumbnail: thumbnail!)
+            let display = MetadataViews.Display(name: name!, description: desc!, thumbnail: thumbnail)
             owned.setDisplay(display)
         }
 
         // Get CapabilityFactory & CapabilityFilter Capabilities
-        let factory = getAccount(factoryAddress).getCapability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)
+        let factory = getAccount(factoryAddress).capabilities.get<&{CapabilityFactory.Getter}>(CapabilityFactory.PublicPath)
+            ?? panic("failed to get factory capability")
         assert(factory.check(), message: "factory address is not configured properly")
 
-        let filter = getAccount(filterAddress).getCapability<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+        let filter = getAccount(filterAddress).capabilities.get<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+            ?? panic("failed to get filter capability")
         assert(filter.check(), message: "capability filter is not configured properly")
 
         // Finally publish a ChildAccount capability on the signing account to the specified parent

--- a/transactions/hybrid-custody/transfer_ownership.cdc
+++ b/transactions/hybrid-custody/transfer_ownership.cdc
@@ -3,8 +3,8 @@
 import "HybridCustody"
 
 transaction(owner: Address) {
-    prepare(acct: AuthAccount) {
-        let owned = acct.borrow<&HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+    prepare(acct: auth(Storage) &Account) {
+        let owned = acct.storage.borrow<auth(HybridCustody.Owner) &HybridCustody.OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
             ?? panic("owned not found")
         owned.giveOwnership(to: owner)
     }

--- a/transactions/hybrid-custody/transfer_ownership_from_manager.cdc
+++ b/transactions/hybrid-custody/transfer_ownership_from_manager.cdc
@@ -3,8 +3,8 @@
 import "HybridCustody"
 
 transaction(ownedAddress: Address, owner: Address) {
-    prepare(acct: AuthAccount) {
-        let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+    prepare(acct: auth(Storage) &Account) {
+        let manager = acct.storage.borrow<auth(HybridCustody.Manage) &HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
             ?? panic("manager not found")
         manager.giveOwnership(addr: ownedAddress, to: owner)
     }

--- a/transactions/hybrid-custody/unlink_child_capability.cdc
+++ b/transactions/hybrid-custody/unlink_child_capability.cdc
@@ -1,0 +1,10 @@
+import "HybridCustody"
+
+transaction(parent: Address) {
+    prepare(acct: auth(Storage, Capabilities) &Account) {
+        let storagePath = StoragePath(identifier: HybridCustody.getChildAccountIdentifier(parent))!
+        for c in acct.capabilities.storage.getControllers(forPath: storagePath) {
+            c.delete()
+        }
+    }
+}

--- a/transactions/misc/unlink_from_storage_paths.cdc
+++ b/transactions/misc/unlink_from_storage_paths.cdc
@@ -1,0 +1,10 @@
+transaction(storagePaths: [StoragePath]) {
+    prepare(acct: auth(Capabilities) &Account) {
+        for storagePath in storagePaths {
+            let controllers = acct.capabilities.storage.getControllers(forPath: storagePath)
+            for con in controllers {
+                acct.capabilities.storage.getController(byCapabilityID: con.capabilityID)?.delete()
+            }
+        }
+    }
+}

--- a/transactions/misc/unlink_paths.cdc
+++ b/transactions/misc/unlink_paths.cdc
@@ -1,7 +1,0 @@
-transaction(paths: [CapabilityPath]) {
-    prepare(acct: AuthAccount) {
-        for p in paths {
-            acct.unlink(p)
-        }
-    }
-}

--- a/transactions/test/add_type_for_nft_provider_factory.cdc
+++ b/transactions/test/add_type_for_nft_provider_factory.cdc
@@ -4,8 +4,8 @@ import "NFTProviderFactory"
 import "NonFungibleToken"
 
 transaction(type: Type) {
-    prepare(account: AuthAccount) {
-        let managerRef = account.borrow<&CapabilityFactory.Manager>(
+    prepare(account: auth(Storage) &Account) {
+        let managerRef = account.storage.borrow<auth(Mutate) &CapabilityFactory.Manager>(
             from: CapabilityFactory.StoragePath
         ) ?? panic("CapabilityFactory Manager not found")
     


### PR DESCRIPTION
This PR covers changes needed to upgrade HybridCustody to Cadence 1.0

Some key points:
1. Private Paths are not going to be in Cadence 1.0, so our standard path for `getCapability` that takes a `CapabilityPath` type had to be moved to take a **Capability Controller ID** instead.
2. Because there are no private paths, we now have to use storage iteration for clearing out existing capabilities when things like ownership updates or sealing change.
3. There are 4 entitlements added to the HybridCustody contract. Three of them map to a resource, and one of them is added just for publishing an account to a parent from a child.
4. ResourceDestroyed events have been added to each core resource type. There was an issue with emitting some fields we might want in the event which might need some follow-up
5. You can no longer get a public capability without <T> so retrieving a public capability had to be moved to the CapabilityFactory interface.
6. Since HybridCustody takes in a full `AuthAccount` reference currently, we have migrated all AuthAccount types to a fully entitled `&Account` reference. It does seem to need nearly all of them with the exception of the `Contract` entitlement.

The main questions coming out of this work as I see them are around Entitlements and whether the use of each entitlement gives us the access control pattern(s) we want. Personally, I had a hard time justifying splitting entitlements beyond each resource type. 