### PR TITLE
Rename NFTCollectionFactory.cdc contract

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,24 +6,23 @@ on:
   push:
     branches: [main]
 
-
 jobs:
   tests:
     name: Flow CLI Tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: "true"
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.18
-    - name: Install Flow CLI
-      run: bash -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/feature/stable-cadence/install.sh)"
-    - name: Run tests
-      run: sh ./test.sh
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/checkout@v3
+        with:
+          submodules: "true"
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - name: Install Flow CLI
+        run: bash -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)"
+      - name: Run tests
+        run: sh ./test.sh
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/contracts/factories/NFTCollectionFactory.cdc
+++ b/contracts/factories/NFTCollectionFactory.cdc
@@ -1,7 +1,7 @@
 import "CapabilityFactory"
 import "NonFungibleToken"
 
-access(all) contract NFTProviderAndCollectionFactory {
+access(all) contract NFTCollectionFactory {
     access(all) struct WithdrawFactory: CapabilityFactory.Factory {
         access(all) view fun getCapability(acct: auth(Capabilities) &Account, controllerID: UInt64): Capability? {
             if let con = acct.capabilities.storage.getController(byCapabilityID: controllerID) {


### PR DESCRIPTION
Closes: #167 

While staging contracts on Mainnet, I realized the contract defined in NFTCollectionFactory is names NFTProviderAndCollectionFactory which collides with another contract. I assume this wasn't caught in #163 so am submitting the fix in this PR.