### PR TITLE
Fix medium and low findings from contract review

### DIFF
--- a/contracts/CapabilityDelegator.cdc
+++ b/contracts/CapabilityDelegator.cdc
@@ -128,6 +128,12 @@ access(all) contract CapabilityDelegator {
         access(Add) fun addCapability(cap: Capability, isPublic: Bool) {
             pre {
                 cap.check<&AnyResource>(): "Invalid Capability provided"
+                // Enforce the invariant that a capability type exists in at most one partition.
+                // Public and private capabilities of the same type cannot and should not be mixed.
+                !isPublic || self.privateCapabilities[cap.getType()] == nil:
+                    "Capability type already exists in the private partition"
+                isPublic || self.publicCapabilities[cap.getType()] == nil:
+                    "Capability type already exists in the public partition"
             }
             if isPublic {
                 self.publicCapabilities.insert(key: cap.getType(), cap)

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -666,7 +666,9 @@ access(all) contract HybridCustody {
         ///
         access(contract) fun setRedeemed(_ addr: Address) {
             let acct = self.childCap.borrow()!._borrowAccount()
-            acct.storage.borrow<&OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)?.setRedeemed(addr)
+            let ownedAcct = acct.storage.borrow<&OwnedAccount>(from: HybridCustody.OwnedAccountStoragePath)
+                ?? panic("OwnedAccount not found at expected storage path during setRedeemed callback")
+            ownedAcct.setRedeemed(addr)
         }
 
         /// Returns a reference to the stored delegator, generally used for arbitrary Capability retrieval
@@ -868,10 +870,8 @@ access(all) contract HybridCustody {
             assert(acct.storage.borrow<&AnyResource>(from: capDelegatorStorage) == nil, message: "conflicting resource found in capability delegator storage slot for parentAddress")
             assert(acct.storage.borrow<&AnyResource>(from: childAccountStorage) == nil, message: "conflicting resource found in child account storage slot for parentAddress")
 
-            if acct.storage.borrow<&CapabilityDelegator.Delegator>(from: capDelegatorStorage) == nil {
-                let delegator <- CapabilityDelegator.createDelegator()
-                acct.storage.save(<-delegator, to: capDelegatorStorage)
-            }
+            let newDelegator <- CapabilityDelegator.createDelegator()
+            acct.storage.save(<-newDelegator, to: capDelegatorStorage)
 
             let capDelegatorPublic = PublicPath(identifier: capDelegatorIdentifier)!
 


### PR DESCRIPTION
## Summary

Addresses three findings from the contract review. All 68 tests pass.

- `ChildAccount.setRedeemed` previously used optional chaining (`?.setRedeemed`) which silently did nothing if `OwnedAccount` was not found at the expected storage path. This could leave `OwnedAccount.parents` stale — the parent would be tracked as active in the `Manager` but remain "pending" in the child forever. Now panics explicitly with a descriptive message.

- `publishToParent` had a dead `if` branch checking whether the delegator storage slot was empty immediately after an `assert` that already guaranteed it was empty. Removed the redundant conditional — the delegator is now created unconditionally (as it always was in practice).

- `CapabilityDelegator.addCapability` had no enforcement of the documented invariant that a capability type should exist in at most one partition (public or private). Added pre-conditions to reject additions that would create a cross-partition type collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)